### PR TITLE
makefiles: distribute .PHONY

### DIFF
--- a/images/client/Makefile
+++ b/images/client/Makefile
@@ -1,13 +1,11 @@
 build:
 	podman build --tag centos8:samba-client -f ./Dockerfile.centos8
+.PHONY: build
 
 tag: build
 	podman tag centos8:samba-client quay.io/obnox/samba-client-centos8:latest
+.PHONY: tag
 
 push: tag
 	podman image push quay.io/obnox/samba-client-centos8:latest
-
-.PHONY: \
-	build \
-	tag \
-	push
+.PHONY: push

--- a/images/samba/Makefile
+++ b/images/samba/Makefile
@@ -1,14 +1,11 @@
-
 build:
 	podman build --tag centos8:samba -f ./Dockerfile.centos8
+.PHONY: build
 
 tag: build
 	podman tag centos8:samba quay.io/obnox/samba-centos8:latest
+.PHONY: tag
 
 push: tag
 	podman image push quay.io/obnox/samba-centos8:latest
-
-.PHONY: \
-	build \
-	tag \
-	push
+.PHONY: push


### PR DESCRIPTION
It is better to have one .PHONY statement for each target,
next to the target. Less error-prone.

Signed-off-by: Michael Adam <obnox@samba.org>