### PR TITLE
[RFC] samba: add a new dockerfile based on fedora and sambacc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PUSH_CMD:=$(CONTAINER_CMD) push $(PUSH_OPTS)
 
 SERVER_DIR:=images/samba
 CLIENT_DIR:=images/client
-SERVER_SRC_FILE:=$(SERVER_DIR)/Dockerfile.centos8
+SERVER_SRC_FILE:=$(SERVER_DIR)/Dockerfile.fedora
 CLIENT_SRC_FILE:=$(CLIENT_DIR)/Dockerfile.centos8
 
 TAG?=latest

--- a/images/samba/Dockerfile.fedora
+++ b/images/samba/Dockerfile.fedora
@@ -1,0 +1,43 @@
+FROM quay.io/phlogistonjohn/sambacc:default AS builder
+
+# the changeset hash on the next line ensures we get a specifc
+# version of sambacc. When sambacc actually gets tagged, it should
+# be changed to use the tag.
+RUN /usr/local/bin/build.sh c8c419ecb406
+
+FROM fedora
+
+MAINTAINER John Mulligan <jmulligan@redhat.com>
+ENV SAMBACC_VERSION="0.1"
+
+COPY smb.conf /etc/samba/smb.conf
+COPY --from=builder \
+    /var/tmp/build/sambacc/dist/sambacc-$SAMBACC_VERSION-py3-none-any.whl \
+    /tmp/sambacc-$SAMBACC_VERSION-py3-none-any.whl
+RUN dnf install -y \
+    findutils \
+    python-pip \
+    python3-jsonschema \
+    python3-samba \
+    samba \
+    samba-client \
+    samba-winbind \
+    samba-winbind-clients \
+    tdb-tools \
+    && pip install /tmp/sambacc-$SAMBACC_VERSION-py3-none-any.whl \
+    && rm -f /tmp/sambacc-$SAMBACC_VERSION-py3-none-any.whl \
+    && ln -s /usr/local/share/sambacc/examples/minimal.json /etc/samba/container.json \
+    && yum clean all \
+    && true
+
+
+VOLUME ["/share"]
+
+EXPOSE 445
+
+ENV SAMBACC_CONFIG="/etc/samba/container.json:/etc/samba/users.json"
+ENV SAMBA_CONTAINER_ID="demo"
+ENTRYPOINT ["samba-container"]
+CMD ["run", "smbd"]
+
+# vim:set syntax=dockerfile:


### PR DESCRIPTION
The sambacc projects provides a script 'samba-container' meant to help
manage samba within a container environment. Fedora provides us
with some newer packages, etc.

Signed-off-by: John Mulligan <jmulligan@redhat.com>