### PR TITLE
Use new org/repos under quay.io/samba.org by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ TAG?=latest
 SERVER_NAME:=samba-container:$(TAG)
 CLIENT_NAME:=samba-client-container:$(TAG)
 SERVER_REPO_NAME:=quay.io/samba.org/samba-server:$(TAG)
-SERVER_REPO_NAME:=quay.io/samba.org/samba-client:$(TAG)
+CLIENT_REPO_NAME:=quay.io/samba.org/samba-client:$(TAG)
 
 
 build: build-server build-client

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ CLIENT_SRC_FILE:=$(CLIENT_DIR)/Dockerfile.centos8
 TAG?=latest
 SERVER_NAME:=samba-container:$(TAG)
 CLIENT_NAME:=samba-client-container:$(TAG)
-SERVER_REPO_NAME:=quay.io/obnox/samba-centos8:$(TAG)
-SERVER_REPO_NAME:=quay.io/obnox/samba-client-centos8:$(TAG)
+SERVER_REPO_NAME:=quay.io/samba.org/samba-server:$(TAG)
+SERVER_REPO_NAME:=quay.io/samba.org/samba-client:$(TAG)
 
 
 build: build-server build-client


### PR DESCRIPTION
Moving away from the personal repo.
Created a new org "samba.org" and repos with more
systematic names under that org.
Use them by default.

Signed-off-by: Michael Adam <obnox@samba.org>