### PR TITLE
github actions: enforce use of podman in the push action

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -32,6 +32,8 @@ jobs:
       - name: log in to quay.io
         run: podman login -u "${{ secrets.QUAY_USER }}" -p "${{ secrets.QUAY_PASS }}" quay.io
       - name: push server image
-        run: make push-server
+        # note: forcing use of podman here, since we did podman login above
+        run: make CONTAINER_CMD=podman push-server
       - name: push client image
-        run: make push-client
+        # note: forcing use of podman here, since we did podman login above
+        run: make CONTAINER_CMD=podman push-client


### PR DESCRIPTION
The env has both docker and podman commands, and the
Makefile has some detection logic that currently prefers
docker.

We are using "podman login" in the yaml, so enforcing
the use of podman in the workflow to fix the post-merge
push action.

Signed-off-by: Michael Adam <obnox@samba.org>