### PR TITLE
examples: add podman based AD joined winbind+smbd pod

### DIFF
--- a/examples/podman/README.md
+++ b/examples/podman/README.md
@@ -1,0 +1,40 @@
+
+# Podman Examples
+
+These examples demonstrate using samba container images with podman.
+
+## Domain Joined SMB Shares
+
+Included here is a shell script and a JSON config template that demonstrates
+using podman to run an smbd instance joined to Active Directory.  Do note that
+the Active Directory in question must already exist and permit new joins using
+the Administrator account. You *must* edit the provided files to match your
+domain/environment.
+
+If you plan to run the pod with rootless podman do note that the smbd processes
+make use of the setuid and setgroups system apis. Rootless podman is restricted
+to a limited set of ids that are controlled by /etc/subuid and /etc/subgid. If
+the ID range configured for winbind exceed these limits the smbd process will
+panic when the user connects to the share. See the
+[rootless podman documentation](https://github.com/containers/podman/blob/master/docs/tutorials/rootless_tutorial.md#etcsubuid-and-etcsubgid-configuration)
+for more detail on this subject.
+
+Example:
+```
+cd ./examples/podman
+# configure the example config for your domain:
+$EDITOR config.json
+# tweak script parameters for your environment:
+$EDITOR smb-wb-pod.sh
+
+./smb-wb-pod.sh /tmp/samba-container-demo start
+# wait a little bit
+smbclient --port 4450 -U 'DOM\User%Pass' //localhost/share
+
+# stop it
+./smb-wb-pod.sh /tmp/samba-container-demo stop
+
+# clean up working dir
+./smb-wb-pod.sh /tmp/samba-container-demo clean
+```
+

--- a/examples/podman/config.json
+++ b/examples/podman/config.json
@@ -1,0 +1,45 @@
+{
+  "samba-container-config": "v0",
+  "configs": {
+    "wbtest": {
+      "shares": [
+        "share"
+      ],
+      "globals": [
+        "noprinting",
+        "wbtest"
+      ],
+      "instance_name": "WB1"
+    }
+  },
+  "shares": {
+    "share": {
+      "options": {
+        "path": "/share",
+        "read only": "no"
+      }
+    }
+  },
+  "_NOTE": "Change the security and workgroup keys to match your domain.",
+  "globals": {
+    "noprinting": {
+      "options": {
+        "load printers": "no",
+        "printing": "bsd",
+        "printcap name": "/dev/null",
+        "disable spoolss": "yes"
+      }
+    },
+    "wbtest": {
+      "options": {
+        "log level": "10",
+        "security": "ads",
+        "workgroup": "CHANGEME",
+        "realm": "CHANGEME.YOURDOMAIN.TLD",
+        "server min protocol": "SMB2",
+        "idmap config * : backend": "autorid",
+        "idmap config * : range": "2000-9999999"
+      }
+    }
+  }
+}

--- a/examples/podman/smb-wb-pod.sh
+++ b/examples/podman/smb-wb-pod.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# This script demonstrates using podman's pods feature to run a smbd
+# and winbind container together, configured via samba-container json.
+# It automatically joins the domain with the password specified below.
+# We don't currently have a secure containerized join so please only
+# use this on scratch testing domains.
+
+set -e
+
+# NOTE: This script depnds on the sambacc config json to:
+#       a) Reside in the same directory as this script
+#       b) Be configured for your AD domain settings
+
+#-- user settable options ---
+#
+# The container image to use
+image=quay.io/samba.org/samba-server:latest
+# The name of the pod
+name=domsamba
+# The port that 445 will be mapped to
+pubport=4450
+# Use the following vars to customize the podman cli for your particular
+# environment
+podextraopts=()
+ctrextraopts=()
+# The AD administrator password for INSECURE join
+ad_password="Passw0rd"
+#----------------------------
+
+workdir="$1"
+
+case "$2" in
+    start)
+        set -x
+
+        mkdir -p "${workdir}"/state/private
+        mkdir -p "${workdir}"/wbsockets
+        mkdir -p "${workdir}"/config
+        mkdir -p "${workdir}"/share
+        chmod 0755 "${workdir}"/wbsockets
+        chmod 0777 "${workdir}"/share
+        cp config.json "${workdir}"/config/config.json
+
+        podman pod create \
+            --hostname="${name}" \
+            --name="${name}" \
+            --share=pid,uts,net \
+            --publish="${pubport}:445" \
+            "${podextraopts[@]}"
+        podman pod start "${name}"
+
+        podman container run \
+            --detach \
+            --pod="${name}" \
+            --name="${name}-wb" \
+            -v "${workdir}/config":/usr/local/etc \
+            -v "${workdir}/state":/var/lib/samba:z \
+            -v "${workdir}/wbsockets":/run/samba/winbindd:z \
+            -e SAMBA_CONTAINER_ID="${name}" \
+            -e SAMBACC_CONFIG="/usr/local/etc/config.json" \
+            "${ctrextraopts[@]}" \
+            "${image}" \
+            --password="${ad_password}" \
+            run \
+            --insecure-auto-join \
+            winbindd
+        sleep 1s
+        podman container run \
+            --detach \
+            --pod="${name}" \
+            --name="${name}-smb" \
+            -v "${workdir}/config":/usr/local/etc \
+            -v "${workdir}/state":/var/lib/samba:z \
+            -v "${workdir}/wbsockets":/run/samba/winbindd:z \
+            -v "${workdir}/share":/share:z \
+            -e SAMBA_CONTAINER_ID="${name}" \
+            -e SAMBACC_CONFIG="/usr/local/etc/config.json" \
+            "${ctrextraopts[@]}" \
+            "${image}" \
+            run \
+            smbd
+    ;;
+    stop)
+        podman pod stop wbtest
+        podman pod rm wbtest
+    ;;
+    restart)
+        "$0" "$1" stop
+        "$0" "$1" start
+    ;;
+    clean)
+        rm -rf "$workdir"
+    ;;
+    *)
+        echo "Run smb filesharing with domain join in podman"
+        echo ""
+        echo "$0 <workdir> {start,stop,clean}"
+        echo "   workdir: the directory to place shared container data"
+        echo "   start:   start the pod"
+        echo "   stop:    stop the pod"
+        echo "   restart: stop and then start the pod"
+        echo "   clean:   remove the shared workdir"
+        echo ""
+        echo "Example:"
+        echo "  $0 /tmp/samba-container-demo start"
+    ;;
+esac


### PR DESCRIPTION
Adds a script, config json template, and readme file to give a brief
into to running samba containers as a domain member.
