### PR TITLE
github actions: provide password via stdin

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: log in to quay.io
-        run: podman login -u "${{ secrets.QUAY_USER }}" -p "${{ secrets.QUAY_PASS }}" quay.io
+        run: echo "${{ secrets.QUAY_PASS }}" | podman login -u "${{ secrets.QUAY_USER }}" --password-stdin quay.io
       - name: push server image
         # note: forcing use of podman here, since we did podman login above
         run: make CONTAINER_CMD=podman push-server


### PR DESCRIPTION
This is more secure than providing the password as a command line
argument to podman login.

Signed-off-by: Michael Adam <obnox@redhat.com>