### PR TITLE
images: use the sambacc container from quay.io/samba.org

### DIFF
--- a/images/server/Dockerfile.fedora
+++ b/images/server/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM quay.io/phlogistonjohn/sambacc:default AS builder
+FROM quay.io/samba.org/sambacc:latest AS builder
 
 # the changeset hash on the next line ensures we get a specifc
 # version of sambacc. When sambacc actually gets tagged, it should


### PR DESCRIPTION
Now that the sambacc projects is pushing its images to
the sambacc repo under quay.io/samba.org, let's use this
image repo instead of John's personal one. :-)

Signed-off-by: Michael Adam <obnox@samba.org>