### PR TITLE
workflows: see if setting BUILDAH_FORMAT creates oci images on quay.io

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -11,6 +11,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      BUILDAH_FORMAT: oci
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
At the moment the images in samba-server appear to have manifest format
"v2s1" which is rather suboptimal. We would prefer oci or at least
docker "v2s2" (version 2 schema 2).

This change is an experiment to see if tweaking this variable gives
us a better result when the CI job pushes to quay.io.


-- Note: this won't do anything particularly useful until it's merged. So once we're certain it doesn't break the build only merging it will do anything helpful.