### PR TITLE
server image: make the the server image build more flexible

### DIFF
--- a/images/server/Dockerfile.fedora
+++ b/images/server/Dockerfile.fedora
@@ -1,9 +1,11 @@
 FROM quay.io/samba.org/sambacc:latest AS builder
+ARG SAMBACC_VER=a2cfac7ae49e
+ARG SAMBACC_REPO=
 
 # the changeset hash on the next line ensures we get a specifc
 # version of sambacc. When sambacc actually gets tagged, it should
 # be changed to use the tag.
-RUN /usr/local/bin/build.sh a2cfac7ae49e
+RUN /usr/local/bin/build.sh ${SAMBACC_VER} ${SAMBACC_REPO}
 
 FROM fedora
 

--- a/images/server/Dockerfile.fedora
+++ b/images/server/Dockerfile.fedora
@@ -13,9 +13,6 @@ MAINTAINER John Mulligan <jmulligan@redhat.com>
 ENV SAMBACC_VERSION="0.1"
 
 COPY smb.conf /etc/samba/smb.conf
-COPY --from=builder \
-    /var/tmp/build/sambacc/dist/sambacc-$SAMBACC_VERSION-py3-none-any.whl \
-    /tmp/sambacc-$SAMBACC_VERSION-py3-none-any.whl
 RUN dnf install -y \
     findutils \
     python-pip \
@@ -26,10 +23,15 @@ RUN dnf install -y \
     samba-winbind \
     samba-winbind-clients \
     tdb-tools \
-    && pip install /tmp/sambacc-$SAMBACC_VERSION-py3-none-any.whl \
+    && dnf clean all \
+    && true
+
+COPY --from=builder \
+    /var/tmp/build/sambacc/dist/sambacc-$SAMBACC_VERSION-py3-none-any.whl \
+    /tmp/sambacc-$SAMBACC_VERSION-py3-none-any.whl
+RUN pip install /tmp/sambacc-$SAMBACC_VERSION-py3-none-any.whl \
     && rm -f /tmp/sambacc-$SAMBACC_VERSION-py3-none-any.whl \
     && ln -s /usr/local/share/sambacc/examples/minimal.json /etc/samba/container.json \
-    && yum clean all \
     && true
 
 


### PR DESCRIPTION
To make it simpler to develop and test changes to sambacc in the server image, allow the use of build args specifying the version/tag/hash and repo from which to build the sambacc wheel.

Split the package install RUN from installing sambacc RUN; by splitting the build this way the layer containing the system packages and that containing sambacc install can be independently cached. The (probably) less frequently changing packages layer may be reused more often than the more frequently changing (for now) sambacc layer.