### PR TITLE
kubernetes examples: fix tags in ctdb example files

### DIFF
--- a/examples/kubernetes/samba-ctdb-dm-sset.yml
+++ b/examples/kubernetes/samba-ctdb-dm-sset.yml
@@ -135,7 +135,7 @@ spec:
     spec:
       shareProcessNamespace: true
       initContainers:
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: init
           args:
@@ -153,7 +153,7 @@ spec:
             name: samba-state-dir
           - mountPath: "/var/lib/ctdb/shared"
             name: ctdb-shared
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: import
           args:
@@ -170,7 +170,7 @@ spec:
             name: samba-state-dir
           - mountPath: "/var/lib/ctdb/shared"
             name: ctdb-shared
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: must-join
           args:
@@ -192,7 +192,7 @@ spec:
           - mountPath: "/etc/join-data"
             name: samba-join-data
             readOnly: true
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb-migrate
           args:
@@ -215,7 +215,7 @@ spec:
             name: ctdb-persistent
           - mountPath: "/var/lib/ctdb/shared"
             name: ctdb-shared
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb-set-node
           args:
@@ -240,7 +240,7 @@ spec:
             name: ctdb-shared
           - mountPath: "/etc/ctdb"
             name: ctdb-config
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb-must-have-node
           args:
@@ -266,7 +266,7 @@ spec:
           - mountPath: "/etc/ctdb"
             name: ctdb-config
       containers:
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb
           args:
@@ -299,7 +299,7 @@ spec:
             name: ctdb-config
           - mountPath: "/var/run/ctdb"
             name: ctdb-sockets-dir
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb-manage-nodes
           args:
@@ -324,7 +324,7 @@ spec:
             name: ctdb-config
           - mountPath: "/var/run/ctdb"
             name: ctdb-sockets-dir
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: smb
           args:
@@ -360,7 +360,7 @@ spec:
             name: ctdb-sockets-dir
           - mountPath: "/run/samba/winbindd"
             name: samba-sockets-dir
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           name: winbind
           args:
           - "--config=/etc/samba-container/config.json"

--- a/examples/kubernetes/samba-ctdb-sset.yml
+++ b/examples/kubernetes/samba-ctdb-sset.yml
@@ -69,7 +69,7 @@ spec:
     spec:
       shareProcessNamespace: true
       initContainers:
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: init
           args:
@@ -85,7 +85,7 @@ spec:
             name: samba-state-dir
           - mountPath: "/var/lib/ctdb/shared"
             name: ctdb-shared
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: import
           args:
@@ -100,7 +100,7 @@ spec:
             name: samba-state-dir
           - mountPath: "/var/lib/ctdb/shared"
             name: ctdb-shared
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: import-users
           args:
@@ -115,7 +115,7 @@ spec:
             name: samba-state-dir
           - mountPath: "/var/lib/ctdb/shared"
             name: ctdb-shared
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb-migrate
           args:
@@ -136,7 +136,7 @@ spec:
             name: ctdb-persistent
           - mountPath: "/var/lib/ctdb/shared"
             name: ctdb-shared
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb-set-node
           args:
@@ -159,7 +159,7 @@ spec:
             name: ctdb-shared
           - mountPath: "/etc/ctdb"
             name: ctdb-config
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb-must-have-node
           args:
@@ -183,7 +183,7 @@ spec:
           - mountPath: "/etc/ctdb"
             name: ctdb-config
       containers:
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb
           args:
@@ -210,7 +210,7 @@ spec:
             name: ctdb-config
           - mountPath: "/var/run/ctdb"
             name: ctdb-sockets-dir
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb-manage-nodes
           args:
@@ -233,7 +233,7 @@ spec:
             name: ctdb-config
           - mountPath: "/var/run/ctdb"
             name: ctdb-sockets-dir
-        - image: quay.io/samba.org/samba-server:ctdb
+        - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: smb
           args:


### PR DESCRIPTION
The container image tag "ctdb" never really existed outside my own local
registry, but I forgot to fix things once the needed (experimental)
support was added to the "latest" container image. This fixes the tags
in the example files.

Signed-off-by: John Mulligan <jmulligan@redhat.com>