### PR TITLE
server: Use the correct hash for sambacc repo

### DIFF
--- a/images/server/Dockerfile.fedora
+++ b/images/server/Dockerfile.fedora
@@ -1,5 +1,5 @@
 FROM quay.io/samba.org/sambacc:latest AS builder
-ARG SAMBACC_VER=b279787f9550
+ARG SAMBACC_VER=f6480c5861a56ef9d1ebb965aebb14732ec2690c
 ARG SAMBACC_REPO=https://github.com/samba-in-kubernetes/sambacc
 
 # the changeset hash on the next line ensures we get a specifc


### PR DESCRIPTION
When building the server image, the git hash for the sambacc repo is
incorrectly set to an old commit. As a result, the server image on
quay.io/samba.org/samba-server:latest
contains an old outdated version of sambacc.

Use the master branch instead when building the server images.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>