### PR TITLE
kubernetes examples: Use vfs_fileid in generated smb.conf

### DIFF
--- a/examples/kubernetes/samba-ctdb-dm-sset.yml
+++ b/examples/kubernetes/samba-ctdb-dm-sset.yml
@@ -30,7 +30,8 @@ data:
           ],
           "globals": [
             "noprinting",
-            "sambadm1"
+            "sambadm1",
+            "vfs_fileid"
           ],
           "instance_features": ["ctdb"],
           "instance_name": "SAMBASWC"
@@ -63,6 +64,12 @@ data:
             "server min protocol": "SMB2",
             "idmap config * : backend": "autorid",
             "idmap config * : range": "2000-9999999"
+          }
+        },
+        "vfs_fileid": {
+          "options": {
+            "vfs objects": "fileid",
+            "fileid:algorithm": "fsid"
           }
         }
       }


### PR DESCRIPTION
Use the vfs_fileid plugin with fsid when using a clustered fs on a PV on
multiple nodes.

Fixes: issue #49

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>