### PR TITLE
Add shellcheck check rule

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -8,6 +8,27 @@ on:
 
 jobs:
 
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    # We need a newer version of shellcheck to avoid problems with the
+    # relative imports. Our scripts work on v0.7.2 and up but not the
+    # v0.7.0 preinstalled in the ubutnu image
+    - name: Update shellcheck
+      run: |
+        shellcheck_version="v0.8.0"
+        url="https://github.com/koalaman/shellcheck/releases/download/${shellcheck_version}/shellcheck-${shellcheck_version}.linux.x86_64.tar.xz"
+        curl -Lo /tmp/shellcheck.tar.xz "$url"
+        mkdir /tmp/shellcheck
+        tar -xf /tmp/shellcheck.tar.xz -C /tmp/shellcheck
+        mkdir -p ~/bin
+        install -m0755 /tmp/shellcheck/shellcheck-${shellcheck_version}/shellcheck  ~/bin/shellcheck
+    - name: Show shellcheck version
+      run: $HOME/bin/shellcheck --version
+    - name: Run static check tools
+      run: make check SHELLCHECK=$HOME/bin/shellcheck
+
   build-server:
     runs-on: ubuntu-latest
     env:

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ endif
 
 BUILD_CMD:=$(CONTAINER_CMD) build $(BUILD_OPTS)
 PUSH_CMD:=$(CONTAINER_CMD) push $(PUSH_OPTS)
+SHELLCHECK:=shellcheck
 
 SERVER_DIR:=images/server
 AD_SERVER_DIR:=images/ad-server
@@ -106,3 +107,12 @@ test-server: build-server
 test-nightly-server: build-nightly-server
 	CONTAINER_CMD=$(CONTAINER_CMD) LOCAL_TAG=$(NIGHTLY_SERVER_NAME) tests/test-samba-container.sh
 .PHONY: test-nightly-server
+
+
+check: check-shell-scripts
+.PHONY: check
+
+# rule requires shellcheck and find to run
+check-shell-scripts:
+	$(SHELLCHECK) -P tests/ -eSC2181 -fgcc $$(find  -name '*.sh')
+.PHONY: check-shell-scripts

--- a/images/server/install-sambacc.sh
+++ b/images/server/install-sambacc.sh
@@ -8,7 +8,7 @@ container_json_file="$2"
 wheeldir=/tmp
 wheel="$(find "${wheeldir}" -type f -name 'sambacc-*.whl')" \
 
-if ! [ $(echo "$wheel" | wc -l) = 1 ]; then
+if ! [ "$(echo "$wheel" | wc -l)" = 1 ]; then
     echo "more than one wheel file found"
     exit 1
 fi

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
 
 SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
-BASE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-AD_DEPLOYMENT_YAML="${SCRIPT_DIR}/files/samba-ad-server-deployment.yml"
-AD_DEPLOYMENT_NAME="samba-ad-server"
-MEMBER_POD_YAML="${SCRIPT_DIR}/files/samba-domain-member-pod.yml"
-MEMBER_POD_NAME="samba-dm"
-MEMBER_CM_NAME="samba-container-config"
-MEMBER_SECRET_NAME="ad-join-secret"
+export AD_DEPLOYMENT_YAML="${SCRIPT_DIR}/files/samba-ad-server-deployment.yml"
+export AD_DEPLOYMENT_NAME="samba-ad-server"
+export MEMBER_POD_YAML="${SCRIPT_DIR}/files/samba-domain-member-pod.yml"
+export MEMBER_POD_NAME="samba-dm"
+export MEMBER_CM_NAME="samba-container-config"
+export MEMBER_SECRET_NAME="ad-join-secret"
 
-KEEP=${KEEP:-0}
+export KEEP=${KEEP:-0}
 
 _error() {
 	echo "$@"

--- a/tests/test-deploy-ad-member.sh
+++ b/tests/test-deploy-ad-member.sh
@@ -28,12 +28,12 @@ until [ $tries -ge 120 ] || echo $podstatus | grep -q 'Running'; do
 	sleep 1
 	echo -n "."
 	tries=$(( tries + 1 ))
-	podstatus="$(kubectl get pod $podname -o go-template='{{.status.phase}}')"
+	podstatus="$(kubectl get pod "$podname" -o go-template='{{.status.phase}}')"
 done
 echo
 kubectl get pod
 echo
-echo $podstatus | grep -q 'Running' || _error "Pod did not reach Running state"
+echo "$podstatus" | grep -q 'Running' || _error "Pod did not reach Running state"
 
 echo "waiting for samba to become reachable"
 tries=0

--- a/tests/test-deploy-ad-server.sh
+++ b/tests/test-deploy-ad-server.sh
@@ -16,10 +16,10 @@ fi
 
 kubectl get deployment
 
-replicaset="$(kubectl describe deployment ${AD_DEPLOYMENT_NAME} | grep -s "NewReplicaSet:" | awk '{ print $2 }')"
+replicaset="$(kubectl describe deployment "${AD_DEPLOYMENT_NAME}" | grep -s "NewReplicaSet:" | awk '{ print $2 }')"
 [ $? -eq 0 ] || _error "Error getting replicaset"
 
-podname="$(kubectl get pod | grep $replicaset | awk '{ print $1 }')"
+podname="$(kubectl get pod | grep "$replicaset" | awk '{ print $1 }')"
 [ $? -eq 0 ] || _error "Error getting podname"
 
 echo "Samba ad pod is $podname"
@@ -31,12 +31,12 @@ until [ $tries -ge 120 ] || echo $podstatus | grep -q 'Running'; do
 	sleep 1
 	echo -n "."
 	tries=$(( tries + 1 ))
-	podstatus="$(kubectl get pod $podname -o go-template='{{.status.phase}}')"
+	podstatus="$(kubectl get pod "$podname" -o go-template='{{.status.phase}}')"
 done
 echo
 kubectl get pod
 echo
-echo $podstatus | grep -q 'Running' || _error "Pod did not reach Running state"
+echo "$podstatus" | grep -q 'Running' || _error "Pod did not reach Running state"
 
 echo "waiting for samba to become reachable"
 tries=0
@@ -76,15 +76,15 @@ echo >> "${TMPFILE}"
 FIRSTLINE="$(head -1 ./tests/files/coredns-snippet.template)"
 LASTLINE="    }"
 
-sed -i .backup -e "/$FIRSTLINE/,/$LASTLINE/d" ${TMPFILE}
+sed -i .backup -e "/$FIRSTLINE/,/$LASTLINE/d" "${TMPFILE}"
 
-cat tests/files/coredns-snippet.template \
-	| sed -e "s/AD_SERVER_IP/${AD_POD_IP}/" \
+sed -e "s/AD_SERVER_IP/${AD_POD_IP}/" \
+	< tests/files/coredns-snippet.template \
 	>> "${TMPFILE}"
 
 echo >> "${TMPFILE}"
 
-kubectl patch cm -n kube-system coredns -p "$(cat ${TMPFILE})"
+kubectl patch cm -n kube-system coredns -p "$(cat "${TMPFILE}")"
 [ $? -eq 0 ] || _error "Error patching coredns config map"
 
 echo "ad setup done"

--- a/tests/test-remove-ad-member.sh
+++ b/tests/test-remove-ad-member.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
 
 source "${SCRIPT_DIR}/common.sh"
 
-if [ ${KEEP} -eq 1 ]; then
+if [ "${KEEP}" -eq 1 ]; then
 	echo "keeping ad member pod (KEEP=1)"
 	exit 0
 fi

--- a/tests/test-remove-ad-server.sh
+++ b/tests/test-remove-ad-server.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
 
 source "${SCRIPT_DIR}/common.sh"
 
-if [ ${KEEP} -eq 1 ]; then
+if [ "${KEEP}" -eq 1 ]; then
 	echo "keeping ad server deployment (KEEP=1)"
 	exit 0
 fi

--- a/tests/test-samba-ad-server-kubernetes.sh
+++ b/tests/test-samba-ad-server-kubernetes.sh
@@ -4,13 +4,13 @@ SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
 
 source "${SCRIPT_DIR}/common.sh"
 
-source ${SCRIPT_DIR}/test-deploy-ad-server.sh
+source "${SCRIPT_DIR}/test-deploy-ad-server.sh"
 
 kubectl exec "${podname}" -- samba-tool domain info 127.0.0.1
 [ $? -eq 0 ] || _error "Error listing domain info"
 echo
 
-source ${SCRIPT_DIR}/test-deploy-ad-member.sh
+source "${SCRIPT_DIR}/test-deploy-ad-member.sh"
 
 kubectl exec "${podname}" -c "smb" -- smbclient -N -L 127.0.0.1
 kubectl exec "${podname}" -c "winbind" -- wbinfo -t
@@ -18,9 +18,9 @@ kubectl exec "${podname}" -c "winbind" -- wbinfo -t
 # to make sure samba can communicate to winbindd
 kubectl exec "${podname}" -c "smb" -- wbinfo -t
 
-source ${SCRIPT_DIR}/test-remove-ad-member.sh
+source "${SCRIPT_DIR}/test-remove-ad-member.sh"
 
-source ${SCRIPT_DIR}/test-remove-ad-server.sh
+source "${SCRIPT_DIR}/test-remove-ad-server.sh"
 
 echo
 echo "Success"


### PR DESCRIPTION
Based on PR: #59 

The samba-container project holds a fair number of shell scripts. Let's use the `shellcheck` static checker on them to avoid common errors.

The patches contain small fix-ups for the scripts, a new makefile rule, and a CI rule to execute the make rule.