### PR TITLE
Run push jobs only within repository and not on forks

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -69,7 +69,7 @@ jobs:
     needs: test-server
 
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository == 'samba-in-kubernetes/samba-container'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
When someone forks the repository, they automatically get the GitHub actions workflow which would then run the push job without proper credentials to push images to quay.io/samba.org registry. Therefore we limit it by checking whether we are within original repository or not.