### PR TITLE
server: allow post-install on image to fit OpenShift

### DIFF
--- a/images/server/Containerfile
+++ b/images/server/Containerfile
@@ -26,6 +26,8 @@ COPY install-sambacc.sh /usr/local/bin/install-sambacc.sh
 RUN /usr/local/bin/install-sambacc.sh \
     "/tmp" "/usr/local/share/sambacc/examples/minimal.json"
 
+COPY post-install-sambacc.sh /usr/local/bin/post-install-sambacc.sh
+RUN /usr/local/bin/post-install-sambacc.sh
 
 VOLUME ["/share"]
 

--- a/images/server/post-install-sambacc.sh
+++ b/images/server/post-install-sambacc.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Some K8S environments (OpenShift) encorage not to run containers with UID=0,
+# though they do allow GID=0. Modify relevant parts of file-system accordingly
+# so that smbd will not get -EPERM.
+set -e
+chmod 770 /etc
+chmod 660 /etc/passwd
+chmod 660 /etc/samba/smb.conf
+chmod 770 /var/lib/samba
+chmod 770 /var/lib/samba/private
+chmod 770 /var/lib/samba/lock


### PR DESCRIPTION
Some K8S environments (OpenShift) encorage not to run containers with UID=0,
though they do allow GID=0. Modify the relevant parts of root file-system
accordingly so that smbd will not get -EPERM when it is trying to modify
the local fs.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>