### PR TITLE
Install sambacc from rpm

### DIFF
--- a/images/ad-server/Containerfile
+++ b/images/ad-server/Containerfile
@@ -19,11 +19,12 @@ COPY install-packages.sh /usr/local/bin/install-packages.sh
 RUN /usr/local/bin/install-packages.sh "$INSTALL_PACKAGES_FROM"
 
 COPY --from=builder \
-    /srv/dist/latest/sambacc-*.whl \
-    /tmp/
+    /srv/dist/latest \
+    /tmp/sambacc-dist-latest
 COPY install-sambacc.sh /usr/local/bin/install-sambacc.sh
 RUN /usr/local/bin/install-sambacc.sh \
-    "/tmp" "/usr/local/share/sambacc/examples/addc.json"
+    "/tmp/sambacc-dist-latest" \
+    && rm -rf /tmp/sambacc-dist-latest
 
 
 ENV SAMBACC_CONFIG="/etc/samba/container.json:/etc/samba/users.json"

--- a/images/ad-server/install-sambacc.sh
+++ b/images/ad-server/install-sambacc.sh
@@ -3,18 +3,46 @@
 set -ex
 
 wheeldir="$1"
-container_json_file="$2"
-
-wheeldir=/tmp
-wheel="$(find "${wheeldir}" -type f -name 'sambacc-*.whl')" \
-
-if ! [ "$(echo "$wheel" | wc -l)" = 1 ]; then
-    echo "more than one wheel file found"
-    exit 1
+if ! [ -d "${wheeldir}" ]; then
+    echo "no directory: ${wheeldir}"
+    exit 2
 fi
 
-pip install "$wheel"
-rm -f "$wheel"
+mapfile -d '' wheels < \
+    <(find "${wheeldir}" -type f -name 'sambacc-*.whl' -print0)
+mapfile -d '' rpmfiles < \
+    <(find "${wheeldir}" -type f -name '*sambacc-*.noarch.rpm' -print0)
+
+
+if [ "${#wheels[@]}" -gt 1 ]; then
+    echo "more than one wheel file found"
+    exit 1
+elif [ "${#wheels[@]}" -eq 1 ]; then
+    action=install-wheel
+fi
+
+if [ "${#rpmfiles[@]}" -gt 1 ]; then
+    echo "more than one rpm file found"
+    exit 1
+elif [ "${#rpmfiles[@]}" -eq 1 ]; then
+    action=install-rpm
+fi
+
+case $action in
+    install-wheel)
+        pip install "${wheels[0]}"
+        container_json_file="/usr/local/share/sambacc/examples/addc.json"
+    ;;
+    install-rpm)
+        dnf install -y "${rpmfiles[0]}"
+        dnf clean all
+        container_json_file="/usr/share/sambacc/examples/addc.json"
+    ;;
+    *)
+        echo "no install package(s) found"
+        exit 1
+    ;;
+esac
 
 if [ "$container_json_file" ]; then
     ln -sf "$container_json_file" /etc/samba/container.json

--- a/images/server/Containerfile
+++ b/images/server/Containerfile
@@ -20,11 +20,12 @@ COPY install-packages.sh /usr/local/bin/install-packages.sh
 RUN /usr/local/bin/install-packages.sh "$INSTALL_PACKAGES_FROM"
 
 COPY --from=builder \
-    /srv/dist/latest/sambacc-*.whl \
-    /tmp/
+    /srv/dist/latest \
+    /tmp/sambacc-dist-latest
 COPY install-sambacc.sh /usr/local/bin/install-sambacc.sh
 RUN /usr/local/bin/install-sambacc.sh \
-    "/tmp" "/usr/local/share/sambacc/examples/minimal.json"
+    "/tmp/sambacc-dist-latest" \
+    && rm -rf /tmp/sambacc-dist-latest
 
 
 VOLUME ["/share"]

--- a/images/server/install-sambacc.sh
+++ b/images/server/install-sambacc.sh
@@ -3,18 +3,46 @@
 set -ex
 
 wheeldir="$1"
-container_json_file="$2"
-
-wheeldir=/tmp
-wheel="$(find "${wheeldir}" -type f -name 'sambacc-*.whl')" \
-
-if ! [ "$(echo "$wheel" | wc -l)" = 1 ]; then
-    echo "more than one wheel file found"
-    exit 1
+if ! [ -d "${wheeldir}" ]; then
+    echo "no directory: ${wheeldir}"
+    exit 2
 fi
 
-pip install "$wheel"
-rm -f "$wheel"
+mapfile -d '' wheels < \
+    <(find "${wheeldir}" -type f -name 'sambacc-*.whl' -print0)
+mapfile -d '' rpmfiles < \
+    <(find "${wheeldir}" -type f -name '*sambacc-*.noarch.rpm' -print0)
+
+
+if [ "${#wheels[@]}" -gt 1 ]; then
+    echo "more than one wheel file found"
+    exit 1
+elif [ "${#wheels[@]}" -eq 1 ]; then
+    action=install-wheel
+fi
+
+if [ "${#rpmfiles[@]}" -gt 1 ]; then
+    echo "more than one rpm file found"
+    exit 1
+elif [ "${#rpmfiles[@]}" -eq 1 ]; then
+    action=install-rpm
+fi
+
+case $action in
+    install-wheel)
+        pip install "${wheels[0]}"
+        container_json_file="/usr/local/share/sambacc/examples/minimal.json"
+    ;;
+    install-rpm)
+        dnf install -y "${rpmfiles[0]}"
+        dnf clean all
+        container_json_file="/usr/share/sambacc/examples/minimal.json"
+    ;;
+    *)
+        echo "no install package(s) found"
+        exit 1
+    ;;
+esac
 
 if [ "$container_json_file" ]; then
     ln -sf "$container_json_file" /etc/samba/container.json


### PR DESCRIPTION
Depends on: samba-in-kubernetes/sambacc#40

Now that sambacc's build image can generate an RPM, use that to install sambacc. I retained the ability to install from a python wheel for now in case we find something strange with the RPM and need to revert. In the not too distant future, if all is fine with the rpm, we can probably drop support from installing from the wheel (unless we decide we want to support non-rpm distros?)

