### PR TITLE
Install python3-pyxattr package on server image

### DIFF
--- a/images/ad-server/install-packages.sh
+++ b/images/ad-server/install-packages.sh
@@ -25,6 +25,7 @@ dnf install --setopt=install_weak_deps=False -y \
     python-pip \
     python3-jsonschema \
     python3-samba \
+    python3-pyxattr \
     samba-dc \
     procps-ng \
     /usr/bin/smbclient

--- a/images/server/install-packages.sh
+++ b/images/server/install-packages.sh
@@ -25,6 +25,7 @@ dnf install --setopt=install_weak_deps=False -y \
     python-pip \
     python3-jsonschema \
     python3-samba \
+    python3-pyxattr \
     samba \
     samba-client \
     samba-winbind \


### PR DESCRIPTION
The new permissions feature to sambacc required the python xattr module.

Signed-off-by: Sachin Prabhu <sprabhu@redhat.com>