### PR TITLE
Specify a version suffix to pin samba versions

### DIFF
--- a/images/ad-server/Containerfile
+++ b/images/ad-server/Containerfile
@@ -11,12 +11,15 @@ RUN SAMBACC_DISTNAME=latest \
 
 FROM registry.fedoraproject.org/fedora:35
 ARG INSTALL_PACKAGES_FROM=default
+ARG SAMBA_VERSION_SUFFIX=""
 ARG SAMBA_SPECIFICS=
 
 MAINTAINER John Mulligan <jmulligan@redhat.com>
 
 COPY install-packages.sh /usr/local/bin/install-packages.sh
-RUN /usr/local/bin/install-packages.sh "$INSTALL_PACKAGES_FROM"
+RUN /usr/local/bin/install-packages.sh \
+    "${INSTALL_PACKAGES_FROM}" \
+    "${SAMBA_VERSION_SUFFIX}"
 
 COPY --from=builder \
     /srv/dist/latest \

--- a/images/ad-server/install-packages.sh
+++ b/images/ad-server/install-packages.sh
@@ -11,8 +11,11 @@ get_custom_repo() {
 }
 
 install_packages_from="$1"
+samba_version_suffix="$2"
 case "${install_packages_from}" in
     samba-nightly)
+        # unset version suffix for nightly builds
+        samba_version_suffix=""
         get_custom_repo "http://artifacts.ci.centos.org/samba/pkgs/master/fedora/samba-nightly-master.repo"
     ;;
     custom-repo)
@@ -26,7 +29,7 @@ dnf install --setopt=install_weak_deps=False -y \
     python3-jsonschema \
     python3-samba \
     python3-pyxattr \
-    samba-dc \
+    "samba-dc${samba_version_suffix}" \
     procps-ng \
     /usr/bin/smbclient
 dnf clean all

--- a/images/server/Containerfile
+++ b/images/server/Containerfile
@@ -11,13 +11,16 @@ RUN SAMBACC_DISTNAME=latest \
 
 FROM registry.fedoraproject.org/fedora:35
 ARG INSTALL_PACKAGES_FROM=default
+ARG SAMBA_VERSION_SUFFIX=""
 ARG SAMBA_SPECIFICS=daemon_cli_debug_output
 
 MAINTAINER John Mulligan <jmulligan@redhat.com>
 
 COPY smb.conf /etc/samba/smb.conf
 COPY install-packages.sh /usr/local/bin/install-packages.sh
-RUN /usr/local/bin/install-packages.sh "$INSTALL_PACKAGES_FROM"
+RUN /usr/local/bin/install-packages.sh \
+    "${INSTALL_PACKAGES_FROM}" \
+    "${SAMBA_VERSION_SUFFIX}"
 
 COPY --from=builder \
     /srv/dist/latest \

--- a/images/server/install-packages.sh
+++ b/images/server/install-packages.sh
@@ -11,8 +11,11 @@ get_custom_repo() {
 }
 
 install_packages_from="$1"
+samba_version_suffix="$2"
 case "${install_packages_from}" in
     samba-nightly)
+        # unset version suffix for nightly builds
+        samba_version_suffix=""
         get_custom_repo "http://artifacts.ci.centos.org/samba/pkgs/master/fedora/samba-nightly-master.repo"
     ;;
     custom-repo)
@@ -26,12 +29,12 @@ dnf install --setopt=install_weak_deps=False -y \
     python3-jsonschema \
     python3-samba \
     python3-pyxattr \
-    samba \
-    samba-client \
-    samba-winbind \
-    samba-winbind-clients \
+    "samba${samba_version_suffix}" \
+    "samba-client${samba_version_suffix}" \
+    "samba-winbind${samba_version_suffix}" \
+    "samba-winbind-clients${samba_version_suffix}" \
     tdb-tools \
-    ctdb
+    "ctdb${samba_version_suffix}"
 dnf clean all
 
 cp --preserve=all /etc/ctdb/functions /usr/share/ctdb/functions


### PR DESCRIPTION
This applies to the server and ad-server container images.

The planned release branch will be able to set the SAMBA_VERSION_SUFFIX build arg to a specific version.