### PR TITLE
Utilize build args to install from custom repo

### DIFF
--- a/images/ad-server/Containerfile
+++ b/images/ad-server/Containerfile
@@ -13,13 +13,15 @@ FROM registry.fedoraproject.org/fedora:35
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
 ARG SAMBA_SPECIFICS=
+ARG INSTALL_CUSTOM_REPO=
 
 MAINTAINER John Mulligan <jmulligan@redhat.com>
 
 COPY install-packages.sh /usr/local/bin/install-packages.sh
 RUN /usr/local/bin/install-packages.sh \
     "${INSTALL_PACKAGES_FROM}" \
-    "${SAMBA_VERSION_SUFFIX}"
+    "${SAMBA_VERSION_SUFFIX}" \
+    "${INSTALL_CUSTOM_REPO}"
 
 COPY --from=builder \
     /srv/dist/latest \

--- a/images/ad-server/install-packages.sh
+++ b/images/ad-server/install-packages.sh
@@ -12,6 +12,7 @@ get_custom_repo() {
 
 install_packages_from="$1"
 samba_version_suffix="$2"
+install_custom_repo="$3"
 case "${install_packages_from}" in
     samba-nightly)
         # unset version suffix for nightly builds
@@ -19,7 +20,7 @@ case "${install_packages_from}" in
         get_custom_repo "http://artifacts.ci.centos.org/samba/pkgs/master/fedora/samba-nightly-master.repo"
     ;;
     custom-repo)
-        get_custom_repo "${INSTALL_CUSTOM_REPO}"
+        get_custom_repo "${install_custom_repo}"
     ;;
 esac
 

--- a/images/server/Containerfile
+++ b/images/server/Containerfile
@@ -13,6 +13,7 @@ FROM registry.fedoraproject.org/fedora:35
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
 ARG SAMBA_SPECIFICS=daemon_cli_debug_output
+ARG INSTALL_CUSTOM_REPO=
 
 MAINTAINER John Mulligan <jmulligan@redhat.com>
 
@@ -20,7 +21,8 @@ COPY smb.conf /etc/samba/smb.conf
 COPY install-packages.sh /usr/local/bin/install-packages.sh
 RUN /usr/local/bin/install-packages.sh \
     "${INSTALL_PACKAGES_FROM}" \
-    "${SAMBA_VERSION_SUFFIX}"
+    "${SAMBA_VERSION_SUFFIX}" \
+    "${INSTALL_CUSTOM_REPO}"
 
 COPY --from=builder \
     /srv/dist/latest \

--- a/images/server/install-packages.sh
+++ b/images/server/install-packages.sh
@@ -12,6 +12,7 @@ get_custom_repo() {
 
 install_packages_from="$1"
 samba_version_suffix="$2"
+install_custom_repo="$3"
 case "${install_packages_from}" in
     samba-nightly)
         # unset version suffix for nightly builds
@@ -19,7 +20,7 @@ case "${install_packages_from}" in
         get_custom_repo "http://artifacts.ci.centos.org/samba/pkgs/master/fedora/samba-nightly-master.repo"
     ;;
     custom-repo)
-        get_custom_repo "${INSTALL_CUSTOM_REPO}"
+        get_custom_repo "${install_custom_repo}"
     ;;
 esac
 


### PR DESCRIPTION
Even though we had **INSTALL_CUSTOM_REPO** variable consumed inside _install-packages.sh_ script it was never exposed to be considered as an input. Therefore we now utilize `--build-arg` to provide valid repository URLs for installing packages.