### PR TITLE
images: bump base image to fedora36

### DIFF
--- a/images/ad-server/Containerfile
+++ b/images/ad-server/Containerfile
@@ -9,7 +9,7 @@ ARG SAMBACC_REPO=https://github.com/samba-in-kubernetes/sambacc
 RUN SAMBACC_DISTNAME=latest \
     /usr/local/bin/build.sh ${SAMBACC_VER} ${SAMBACC_REPO}
 
-FROM registry.fedoraproject.org/fedora:35
+FROM registry.fedoraproject.org/fedora:36
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
 ARG SAMBA_SPECIFICS=

--- a/images/server/Containerfile
+++ b/images/server/Containerfile
@@ -9,7 +9,7 @@ ARG SAMBACC_REPO=https://github.com/samba-in-kubernetes/sambacc
 RUN SAMBACC_DISTNAME=latest \
     /usr/local/bin/build.sh ${SAMBACC_VER} ${SAMBACC_REPO}
 
-FROM registry.fedoraproject.org/fedora:35
+FROM registry.fedoraproject.org/fedora:36
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
 ARG SAMBA_SPECIFICS=daemon_cli_debug_output


### PR DESCRIPTION
Expects Fedora36 to be maintained until mid 2023.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>