### PR TITLE
images/client: add 'samba-test'

### DIFF
--- a/images/client/Dockerfile
+++ b/images/client/Dockerfile
@@ -4,4 +4,4 @@ FROM quay.io/centos/centos:stream8
 
 MAINTAINER Michael Adam <obnox@samba.org>
 
-RUN dnf -y install samba-client
+RUN dnf -y install samba-client samba-test


### PR DESCRIPTION
Allow using the samba-client image for testing, via the 'smbtorture' utility.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>