### PR TITLE
client: use fedora36 as base image

### DIFF
--- a/images/client/Containerfile
+++ b/images/client/Containerfile
@@ -1,6 +1,6 @@
 # Copyright 2020 Michael Adam
 
-FROM quay.io/centos/centos:stream8
+FROM registry.fedoraproject.org/fedora:36
 
 MAINTAINER Michael Adam <obnox@samba.org>
 


### PR DESCRIPTION
Align client to same base image as server and ad-server, as well as base image used by sambacc. Allows the container engine to share image-layers between containers.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>