### PR TITLE
makefile: add build-toolbox to general build rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,8 @@ BUILDFILE_NIGHTLY_AD_SERVER:=.build.nightly-ad-server
 BUILDFILE_CLIENT:=.build.client
 BUILDFILE_TOOLBOX:=.build.toolbox
 
-build: build-server build-nightly-server build-ad-server build-client
+build: build-server build-nightly-server build-ad-server build-client \
+	build-toolbox
 .PHONY: build
 
 build-server: $(BUILDFILE_SERVER)


### PR DESCRIPTION
The build rule exists to build everything, so it should include the new toolbox container too.

Signed-off-by: John Mulligan <jmulligan@redhat.com>