### PR TITLE
toolbox: use fedora36 as base image

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -77,7 +77,7 @@ jobs:
       BUILDAH_FORMAT: oci
     steps:
     - uses: actions/checkout@v3
-    - name: Build the client image
+    - name: Build the toolbox image
       run: make build-toolbox
 
   test-server:

--- a/images/toolbox/Containerfile
+++ b/images/toolbox/Containerfile
@@ -1,3 +1,3 @@
-FROM quay.io/samba.org/samba-client:latest
+FROM registry.fedoraproject.org/fedora:36
 MAINTAINER Shachar Sharon <ssharon@redhat.com>
-RUN dnf -y install samba-test
+RUN dnf -y install samba-client samba-test


### PR DESCRIPTION
When using samba-client as base image for toolbox, we get an enigmatic failure due to dnf dependencies conflict. This does not appear to be related to samba packages but rather to something in dnf internal database. Avoid this problem by using fedora:36 as base image.

Refs:
  https://github.com/samba-in-kubernetes/samba-container/issues/96

Signed-off-by: Shachar Sharon <ssharon@redhat.com>