### PR TITLE
images: Use `samba-client` as base image for `samba-toolbox` build

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -70,13 +70,27 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build the client image
       run: make build-client
+    # Here we upload samba-client image to artifacts locally for consumption
+    # during samba-toolbox build process.
+    - name: Upload client image
+      uses: ishworkh/docker-image-artifact-upload@v1
+      with:
+        image: "quay.io/samba.org/samba-client:latest"
+        retention_days: 1
 
   build-toolbox:
+    needs: build-client
     runs-on: ubuntu-latest
     env:
       BUILDAH_FORMAT: oci
     steps:
     - uses: actions/checkout@v3
+    # Download locally stored samba-client image to be used as base for building
+    # samba-toolbox.
+    - name: Download client image
+      uses: ishworkh/docker-image-artifact-download@v1
+      with:
+        image: "quay.io/samba.org/samba-client:latest"
     - name: Build the toolbox image
       run: make build-toolbox
 

--- a/images/client/Containerfile
+++ b/images/client/Containerfile
@@ -4,4 +4,11 @@ FROM registry.fedoraproject.org/fedora:36
 
 MAINTAINER Michael Adam <obnox@samba.org>
 
-RUN dnf -y install samba-client
+# https://github.com/samba-in-kubernetes/samba-container/issues/96#issuecomment-1387467396
+#
+# samba-common, when pulled in as a dependency for samba-client, has a preferred
+# requirement on systemd-standalone-tmpfiles(rather than systemd) but is meant
+# to conflict with systemd itself of same version or higher. We can avoid the
+# conflict by choosing to install systemd over systemd-standalone-tmpfiles.
+RUN dnf -y install samba-client systemd \
+    && dnf clean all

--- a/images/toolbox/Containerfile
+++ b/images/toolbox/Containerfile
@@ -1,3 +1,4 @@
-FROM registry.fedoraproject.org/fedora:36
+FROM quay.io/samba.org/samba-client:latest
 MAINTAINER Shachar Sharon <ssharon@redhat.com>
-RUN dnf -y install samba-client samba-test
+RUN dnf -y install samba-test \
+    && dnf clean all


### PR DESCRIPTION
This change partially reverts 91b87790ca267fca50b2b90acd90bf32f5830dc6 and explicilty installs **systemd** along with **samba-client** so that package conflict problem from https://github.com/samba-in-kubernetes/samba-container/issues/96 never arises.

Additionally share _samba-client_ image to be consumed within _samba-toolbox_ build process for GitHub action workflow. 

fixes #96 