### PR TITLE
Proposal2: openSUSE base images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 .build.client
 .build.opensuse-client
 .build.toolbox
+.build.opensuse-toolbox
 .build.nightly.server
 .build.nightly.ad-server

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 .build.server
+.build.opensuse-server
 .build.ad-server
 .build.client
 .build.toolbox

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .build.ad-server
 .build.opensuse-ad-server
 .build.client
+.build.opensuse-client
 .build.toolbox
 .build.nightly.server
 .build.nightly.ad-server

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .build.server
 .build.opensuse-server
 .build.ad-server
+.build.opensuse-ad-server
 .build.client
 .build.toolbox
 .build.nightly.server

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ SERVER_DIR:=images/server
 AD_SERVER_DIR:=images/ad-server
 CLIENT_DIR:=images/client
 TOOLBOX_DIR:=images/toolbox
-SERVER_SRC_FILE:=$(SERVER_DIR)/Containerfile
+SERVER_SRC_FILE:=$(SERVER_DIR)/Containerfile.fedora
 SERVER_SOURCES:=\
 	$(SERVER_DIR)/smb.conf \
 	$(SERVER_DIR)/install-packages.sh \

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ AD_SERVER_SOURCES:=\
 	$(AD_SERVER_DIR)/install-packages.sh \
 	$(AD_SERVER_DIR)/install-sambacc.sh
 CLIENT_SRC_FILE:=$(CLIENT_DIR)/Containerfile.fedora
-TOOLBOX_SRC_FILE:=$(TOOLBOX_DIR)/Containerfile
+TOOLBOX_SRC_FILE:=$(TOOLBOX_DIR)/Containerfile.fedora
 
 TAG?=latest
 SERVER_NAME:=samba-container:$(TAG)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ SERVER_SOURCES:=\
 	$(SERVER_DIR)/smb.conf \
 	$(SERVER_DIR)/install-packages.sh \
 	$(SERVER_DIR)/install-sambacc.sh
-AD_SERVER_SRC_FILE:=$(AD_SERVER_DIR)/Containerfile
+AD_SERVER_SRC_FILE:=$(AD_SERVER_DIR)/Containerfile.fedora
 AD_SERVER_SOURCES:=\
 	$(AD_SERVER_DIR)/install-packages.sh \
 	$(AD_SERVER_DIR)/install-sambacc.sh

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ AD_SERVER_SRC_FILE:=$(AD_SERVER_DIR)/Containerfile.fedora
 AD_SERVER_SOURCES:=\
 	$(AD_SERVER_DIR)/install-packages.sh \
 	$(AD_SERVER_DIR)/install-sambacc.sh
-CLIENT_SRC_FILE:=$(CLIENT_DIR)/Containerfile
+CLIENT_SRC_FILE:=$(CLIENT_DIR)/Containerfile.fedora
 TOOLBOX_SRC_FILE:=$(TOOLBOX_DIR)/Containerfile
 
 TAG?=latest

--- a/Makefile.opensuse
+++ b/Makefile.opensuse
@@ -3,13 +3,17 @@ include Makefile
 SERVER_SRC_FILE:=$(SERVER_DIR)/Containerfile.opensuse
 AD_SERVER_SRC_FILE:=$(AD_SERVER_DIR)/Containerfile.opensuse
 CLIENT_SRC_FILE:=$(CLIENT_DIR)/Containerfile.opensuse
+TOOLBOX_SRC_FILE:=$(TOOLBOX_DIR)/Containerfile.opensuse
 SERVER_SOURCES:=$(SERVER_DIR)/smb.conf
 SERVER_NAME:=samba-opensuse-container:$(TAG)
 AD_SERVER_NAME:=samba-ad-opensuse-container:$(TAG)
 CLIENT_NAME:=samba-client-opensuse-container:$(TAG)
+TOOLBOX_NAME:=samba-toolbox-opensuse-container:$(TAG)
 SERVER_REPO_NAME:=registry.opensuse.org/opensuse/samba-server:$(TAG)
 AD_SERVER_REPO_NAME:=registry.opensuse.org/opensuse/samba-ad-server:$(TAG)
 CLIENT_REPO_NAME:=registry.opensuse.org/opensuse/samba-client:$(TAG)
+TOOLBOX_REPO_NAME:=registry.opensuse.org/opensuse/samba-toolbox:$(TAG)
 BUILDFILE_SERVER:=.build.opensuse-server
 BUILDFILE_AD_SERVER:=.build.opensuse-ad-server
 BUILDFILE_CLIENT:=.build.opensuse-client
+BUILDFILE_TOOLBOX:=.build.opensuse-toolbox

--- a/Makefile.opensuse
+++ b/Makefile.opensuse
@@ -2,10 +2,14 @@ include Makefile
 
 SERVER_SRC_FILE:=$(SERVER_DIR)/Containerfile.opensuse
 AD_SERVER_SRC_FILE:=$(AD_SERVER_DIR)/Containerfile.opensuse
+CLIENT_SRC_FILE:=$(CLIENT_DIR)/Containerfile.opensuse
 SERVER_SOURCES:=$(SERVER_DIR)/smb.conf
 SERVER_NAME:=samba-opensuse-container:$(TAG)
 AD_SERVER_NAME:=samba-ad-opensuse-container:$(TAG)
+CLIENT_NAME:=samba-client-opensuse-container:$(TAG)
 SERVER_REPO_NAME:=registry.opensuse.org/opensuse/samba-server:$(TAG)
 AD_SERVER_REPO_NAME:=registry.opensuse.org/opensuse/samba-ad-server:$(TAG)
+CLIENT_REPO_NAME:=registry.opensuse.org/opensuse/samba-client:$(TAG)
 BUILDFILE_SERVER:=.build.opensuse-server
 BUILDFILE_AD_SERVER:=.build.opensuse-ad-server
+BUILDFILE_CLIENT:=.build.opensuse-client

--- a/Makefile.opensuse
+++ b/Makefile.opensuse
@@ -1,7 +1,11 @@
 include Makefile
 
 SERVER_SRC_FILE:=$(SERVER_DIR)/Containerfile.opensuse
+AD_SERVER_SRC_FILE:=$(AD_SERVER_DIR)/Containerfile.opensuse
 SERVER_SOURCES:=$(SERVER_DIR)/smb.conf
 SERVER_NAME:=samba-opensuse-container:$(TAG)
+AD_SERVER_NAME:=samba-ad-opensuse-container:$(TAG)
 SERVER_REPO_NAME:=registry.opensuse.org/opensuse/samba-server:$(TAG)
+AD_SERVER_REPO_NAME:=registry.opensuse.org/opensuse/samba-ad-server:$(TAG)
 BUILDFILE_SERVER:=.build.opensuse-server
+BUILDFILE_AD_SERVER:=.build.opensuse-ad-server

--- a/Makefile.opensuse
+++ b/Makefile.opensuse
@@ -1,0 +1,7 @@
+include Makefile
+
+SERVER_SRC_FILE:=$(SERVER_DIR)/Containerfile.opensuse
+SERVER_SOURCES:=$(SERVER_DIR)/smb.conf
+SERVER_NAME:=samba-opensuse-container:$(TAG)
+SERVER_REPO_NAME:=registry.opensuse.org/opensuse/samba-server:$(TAG)
+BUILDFILE_SERVER:=.build.opensuse-server

--- a/images/ad-server/Containerfile.fedora
+++ b/images/ad-server/Containerfile.fedora
@@ -17,6 +17,10 @@ ARG INSTALL_CUSTOM_REPO=
 
 MAINTAINER John Mulligan <jmulligan@redhat.com>
 
+LABEL org.opencontainers.image.title="Samba ADDC container"
+LABEL org.opencontainers.image.description="Samba ADDC container"
+LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
+
 COPY install-packages.sh /usr/local/bin/install-packages.sh
 RUN /usr/local/bin/install-packages.sh \
     "${INSTALL_PACKAGES_FROM}" \

--- a/images/ad-server/Containerfile.opensuse
+++ b/images/ad-server/Containerfile.opensuse
@@ -1,0 +1,47 @@
+# Defines the tag for OBS and build script builds:
+#!BuildTag: opensuse/samba-ad-server:latest
+#!BuildTag: opensuse/samba-ad-server:%%MINOR%%
+#!BuildTag: opensuse/samba-ad-server:%%PKG_VERSION%%
+#!BuildTag: opensuse/samba-ad-server:%%PKG_VERSION%%-%RELEASE%
+
+# OBS doesn't allow a fully qualified image registry name for the offline build
+FROM opensuse/tumbleweed
+ARG SAMBA_SPECIFICS=
+
+MAINTAINER David Mulder <dmulder@suse.com>
+
+# labelprefix=org.opensuse.samba-ad-server
+LABEL org.opencontainers.image.title="Samba ADDC container"
+LABEL org.opencontainers.image.description="Samba ADDC container"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+LABEL org.opencontainers.image.version="%%PKG_VERSION%%-%RELEASE%"
+LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL org.opensuse.reference="registry.opensuse.org/opensuse/samba-ad-server:%%PKG_VERSION%%-%RELEASE%"
+# endlabelprefix
+
+RUN zypper --non-interactive install --no-recommends \
+  findutils \
+  python3-pip \
+  python3-jsonschema \
+  samba-python3 \
+  python3-pyxattr \
+  samba-ad-dc \
+  procps \
+  samba-client \
+  samba-winbind \
+  python3-dnspython \
+  krb5-server \
+  sambacc && \
+  zypper clean;
+RUN ln -sf /usr/share/sambacc/examples/addc.json /etc/samba/container.json
+RUN rm -rf /etc/samba/smb.conf
+
+
+ENV SAMBACC_CONFIG="/etc/samba/container.json:/etc/samba/users.json"
+ENV SAMBA_CONTAINER_ID="demo"
+ENV SAMBA_SPECIFICS="$SAMBA_SPECIFICS"
+ENTRYPOINT ["samba-dc-container"]
+CMD ["run", "--setup=provision", "--setup=populate"]
+
+# vim:set syntax=dockerfile:

--- a/images/client/Containerfile.fedora
+++ b/images/client/Containerfile.fedora
@@ -4,6 +4,10 @@ FROM registry.fedoraproject.org/fedora:36
 
 MAINTAINER Michael Adam <obnox@samba.org>
 
+LABEL org.opencontainers.image.title="Samba Client container"
+LABEL org.opencontainers.image.description="Samba Client container"
+LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
+
 # https://github.com/samba-in-kubernetes/samba-container/issues/96#issuecomment-1387467396
 #
 # samba-common, when pulled in as a dependency for samba-client, has a preferred

--- a/images/client/Containerfile.opensuse
+++ b/images/client/Containerfile.opensuse
@@ -1,0 +1,21 @@
+# Defines the tag for OBS and build script builds:
+#!BuildTag: opensuse/samba-client:latest
+#!BuildTag: opensuse/samba-client:%%MINOR%%
+#!BuildTag: opensuse/samba-client:%%PKG_VERSION%%
+#!BuildTag: opensuse/samba-client:%%PKG_VERSION%%-%RELEASE%
+
+# OBS doesn't allow a fully qualified image registry name for the offline build
+FROM opensuse/tumbleweed
+MAINTAINER David Mulder <dmulder@suse.com>
+
+# labelprefix=org.opensuse.samba-client
+LABEL org.opencontainers.image.title="Samba Client container"
+LABEL org.opencontainers.image.description="Samba Client container"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+LABEL org.opencontainers.image.version="%%PKG_VERSION%%-%RELEASE%"
+LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL org.opensuse.reference="registry.opensuse.org/opensuse/samba-client:%%PKG_VERSION%%-%RELEASE%"
+# endlabelprefix
+
+RUN zypper --non-interactive install --no-recommends samba-client && zypper clean

--- a/images/server/Containerfile.fedora
+++ b/images/server/Containerfile.fedora
@@ -17,6 +17,10 @@ ARG INSTALL_CUSTOM_REPO=
 
 MAINTAINER John Mulligan <jmulligan@redhat.com>
 
+LABEL org.opencontainers.image.title="Samba container"
+LABEL org.opencontainers.image.description="Samba container"
+LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
+
 COPY smb.conf /etc/samba/smb.conf
 COPY install-packages.sh /usr/local/bin/install-packages.sh
 RUN /usr/local/bin/install-packages.sh \

--- a/images/server/Containerfile.opensuse
+++ b/images/server/Containerfile.opensuse
@@ -1,0 +1,50 @@
+# Defines the tag for OBS and build script builds:
+#!BuildTag: opensuse/samba-server:latest
+#!BuildTag: opensuse/samba-server:%%MINOR%%
+#!BuildTag: opensuse/samba-server:%%PKG_VERSION%%
+#!BuildTag: opensuse/samba-server:%%PKG_VERSION%%-%RELEASE%
+
+# OBS doesn't allow a fully qualified image registry name for the offline build
+FROM opensuse/tumbleweed
+ARG SAMBA_SPECIFICS=daemon_cli_debug_output,ctdb_leader_admin_command
+
+MAINTAINER David Mulder <dmulder@suse.com>
+
+# labelprefix=org.opensuse.samba-server
+LABEL org.opencontainers.image.title="Samba container"
+LABEL org.opencontainers.image.description="Samba container"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+LABEL org.opencontainers.image.version="%%PKG_VERSION%%-%RELEASE%"
+LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL org.opensuse.reference="registry.opensuse.org/opensuse/samba-server:%%PKG_VERSION%%-%RELEASE%"
+# endlabelprefix
+
+COPY smb.conf /etc/samba/smb.conf
+RUN zypper --non-interactive install --no-recommends \
+  findutils \
+  python3-pip \
+  python3-jsonschema \
+  samba-python3 \
+  python3-pyxattr \
+  samba \
+  samba-winbind \
+  tdb-tools \
+  ctdb \
+  glibc \
+  sambacc && \
+  zypper clean;
+RUN ln -sf /usr/share/sambacc/examples/minimal.json /etc/samba/container.json
+
+
+VOLUME ["/share"]
+
+EXPOSE 445
+
+ENV SAMBACC_CONFIG="/etc/samba/container.json:/etc/samba/users.json"
+ENV SAMBA_CONTAINER_ID="demo"
+ENV SAMBA_SPECIFICS="$SAMBA_SPECIFICS"
+ENTRYPOINT ["samba-container"]
+CMD ["run", "smbd"]
+
+# vim:set syntax=dockerfile:

--- a/images/toolbox/Containerfile
+++ b/images/toolbox/Containerfile
@@ -1,4 +1,0 @@
-FROM quay.io/samba.org/samba-client:latest
-MAINTAINER Shachar Sharon <ssharon@redhat.com>
-RUN dnf -y install samba-test \
-    && dnf clean all

--- a/images/toolbox/Containerfile.fedora
+++ b/images/toolbox/Containerfile.fedora
@@ -1,0 +1,9 @@
+FROM quay.io/samba.org/samba-client:latest
+MAINTAINER Shachar Sharon <ssharon@redhat.com>
+
+LABEL org.opencontainers.image.title="Samba Toolbox container"
+LABEL org.opencontainers.image.description="Samba Toolbox container"
+LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
+
+RUN dnf -y install samba-test \
+    && dnf clean all

--- a/images/toolbox/Containerfile.opensuse
+++ b/images/toolbox/Containerfile.opensuse
@@ -1,0 +1,21 @@
+# Defines the tag for OBS and build script builds:
+#!BuildTag: opensuse/samba-toolbox:latest
+#!BuildTag: opensuse/samba-toolbox:%%MINOR%%
+#!BuildTag: opensuse/samba-toolbox:%%PKG_VERSION%%
+#!BuildTag: opensuse/samba-toolbox:%%PKG_VERSION%%-%RELEASE%
+
+# OBS doesn't allow a fully qualified image registry name for the offline build
+FROM opensuse/tumbleweed
+MAINTAINER David Mulder <dmulder@suse.com>
+
+# labelprefix=org.opensuse.samba-toolbox
+LABEL org.opencontainers.image.title="Samba Toolbox container"
+LABEL org.opencontainers.image.description="Samba Toolbox container"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+LABEL org.opencontainers.image.version="%%PKG_VERSION%%-%RELEASE%"
+LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL org.opensuse.reference="registry.opensuse.org/opensuse/samba-toolbox:%%PKG_VERSION%%-%RELEASE%"
+# endlabelprefix
+
+RUN zypper --non-interactive install --no-recommends samba-client samba-test && zypper clean


### PR DESCRIPTION
This is a new proposal for adding openSUSE images, using new Containerfiles. This moves all the existing Containerfile names to Containerfile.fedora, and creates new Containerfile names called Containerfile.opensuse. I've also added a couple of opencontainer flags to the Fedora containers (excluding the build time/versions/etc since I don't know how this works in Fedora).

I intentionally excluded the opensuse images from the general build, since we won't be using the Makefile for generating our images anyway, though I added the make rule 'build-opensuse' for easy test builds. Also, I included 'build-opensuse-server' in `make test` (and have it run a the tests on it).

FYI, these builds currently fail locally, because the sambacc package hasn't been approved for Tumbleweed yet (I'm working on this). These do succeed within my OBS build environment.