### PR TITLE
add tdb-tools to ad-server and toolbox images

### DIFF
--- a/images/ad-server/install-packages.sh
+++ b/images/ad-server/install-packages.sh
@@ -29,6 +29,7 @@ dnf install --setopt=install_weak_deps=False -y \
     python-pip \
     python3-samba \
     python3-pyxattr \
+    tdb-tools \
     "samba-dc${samba_version_suffix}" \
     procps-ng \
     /usr/bin/smbclient

--- a/images/toolbox/Containerfile.fedora
+++ b/images/toolbox/Containerfile.fedora
@@ -6,4 +6,5 @@ LABEL org.opencontainers.image.description="Samba Toolbox container"
 LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
 
 RUN dnf -y install samba-test \
+    tdb-tools \
     && dnf clean all

--- a/images/toolbox/Containerfile.opensuse
+++ b/images/toolbox/Containerfile.opensuse
@@ -18,4 +18,4 @@ LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL org.opensuse.reference="registry.opensuse.org/opensuse/samba-toolbox:%%PKG_VERSION%%-%RELEASE%"
 # endlabelprefix
 
-RUN zypper --non-interactive install --no-recommends samba-client samba-test && zypper clean
+RUN zypper --non-interactive install --no-recommends samba-client samba-test tdb-tools && zypper clean


### PR DESCRIPTION
Including tdb tools will permit the use of programs like tdbbackup
to be used from within the AD DC container.

Fixes: #113


----

Also add tdb-tools to the toolbox images, since they are tools.