### PR TITLE
drop jsonschema rpms

### DIFF
--- a/images/ad-server/install-packages.sh
+++ b/images/ad-server/install-packages.sh
@@ -27,7 +27,6 @@ esac
 dnf install --setopt=install_weak_deps=False -y \
     findutils \
     python-pip \
-    python3-jsonschema \
     python3-samba \
     python3-pyxattr \
     "samba-dc${samba_version_suffix}" \

--- a/images/server/install-packages.sh
+++ b/images/server/install-packages.sh
@@ -27,7 +27,6 @@ esac
 dnf install --setopt=install_weak_deps=False -y \
     findutils \
     python-pip \
-    python3-jsonschema \
     python3-samba \
     python3-pyxattr \
     "samba${samba_version_suffix}" \


### PR DESCRIPTION
 Temporarily remove jsonschema from our packages list. sambacc tries to
    use this package but is not compatible with the version in fedora 36
