### PR TITLE
install sambacc using common script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .build.opensuse-toolbox
 .build.nightly.server
 .build.nightly.ad-server
+.common

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ ALT_BIN=$(CURDIR)/.bin
 SHELLCHECK=$(shell command -v shellcheck || echo $(ALT_BIN)/shellcheck)
 GITLINT=$(shell command -v gitlint || echo $(ALT_BIN)/gitlint)
 
+COMMON_DIR:=images/common
 SERVER_DIR:=images/server
 AD_SERVER_DIR:=images/ad-server
 CLIENT_DIR:=images/client
@@ -278,7 +279,7 @@ clean:
 # SRC_FILE: path to the Containerfile (Dockerfile)
 # DIR: path to the directory holding image contents
 # BUILDFILE: path to a temporary file tracking build state
-_img_build:
+_img_build: $(DIR)/.common
 	$(BUILD_CMD) \
 		$(BUILD_ARGS) \
 		$(EXTRA_BUILD_ARGS) \
@@ -289,6 +290,9 @@ _img_build:
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(SHORT_NAME) > $(BUILDFILE)
 .PHONY: _img_build
 
+$(DIR)/.common: $(COMMON_DIR)
+	$(RM) -r $(DIR)/.common
+	cp -r $(COMMON_DIR) $(DIR)/.common
 
 $(ALT_BIN)/%:
 	$(CURDIR)/hack/install-tools.sh --$* $(ALT_BIN)

--- a/images/ad-server/Containerfile.fedora
+++ b/images/ad-server/Containerfile.fedora
@@ -30,6 +30,7 @@ RUN /usr/local/bin/install-packages.sh \
 COPY --from=builder \
     /srv/dist/latest \
     /tmp/sambacc-dist-latest
+COPY .common/install-sambacc-common.sh /usr/local/bin/install-sambacc-common.sh
 COPY install-sambacc.sh /usr/local/bin/install-sambacc.sh
 RUN /usr/local/bin/install-sambacc.sh \
     "/tmp/sambacc-dist-latest" \

--- a/images/ad-server/install-sambacc.sh
+++ b/images/ad-server/install-sambacc.sh
@@ -2,48 +2,7 @@
 
 set -ex
 
-wheeldir="$1"
-if ! [ -d "${wheeldir}" ]; then
-    echo "no directory: ${wheeldir}"
-    exit 2
-fi
-
-mapfile -d '' wheels < \
-    <(find "${wheeldir}" -type f -name 'sambacc-*.whl' -print0)
-mapfile -d '' rpmfiles < \
-    <(find "${wheeldir}" -type f -name '*sambacc-*.noarch.rpm' -print0)
-
-
-if [ "${#wheels[@]}" -gt 1 ]; then
-    echo "more than one wheel file found"
-    exit 1
-elif [ "${#wheels[@]}" -eq 1 ]; then
-    action=install-wheel
-fi
-
-if [ "${#rpmfiles[@]}" -gt 1 ]; then
-    echo "more than one rpm file found"
-    exit 1
-elif [ "${#rpmfiles[@]}" -eq 1 ]; then
-    action=install-rpm
-fi
-
-case $action in
-    install-wheel)
-        pip install "${wheels[0]}"
-        container_json_file="/usr/local/share/sambacc/examples/addc.json"
-    ;;
-    install-rpm)
-        dnf install -y "${rpmfiles[0]}"
-        dnf clean all
-        container_json_file="/usr/share/sambacc/examples/addc.json"
-    ;;
-    *)
-        echo "no install package(s) found"
-        exit 1
-    ;;
-esac
-
-if [ "$container_json_file" ]; then
-    ln -sf "$container_json_file" /etc/samba/container.json
-fi
+# shellcheck source=images/common/install-sambacc-common.sh
+. install-sambacc-common.sh
+export DEFAULT_JSON_FILE=addc.json
+install_sambacc "$@"

--- a/images/common/install-sambacc-common.sh
+++ b/images/common/install-sambacc-common.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+install_sambacc() {
+    wheeldir="$1"
+    if ! [ -d "${wheeldir}" ]; then
+        echo "no directory: ${wheeldir}"
+        exit 2
+    fi
+
+    mapfile -d '' wheels < \
+        <(find "${wheeldir}" -type f -name 'sambacc-*.whl' -print0)
+    mapfile -d '' rpmfiles < \
+        <(find "${wheeldir}" -type f -name '*sambacc-*.noarch.rpm' -print0)
+
+
+    if [ "${#wheels[@]}" -gt 1 ]; then
+        echo "more than one wheel file found"
+        exit 1
+    elif [ "${#wheels[@]}" -eq 1 ]; then
+        action=install-wheel
+    fi
+
+    if [ "${#rpmfiles[@]}" -gt 1 ]; then
+        echo "more than one rpm file found"
+        exit 1
+    elif [ "${#rpmfiles[@]}" -eq 1 ]; then
+        action=install-rpm
+    fi
+
+    if [ -z "${DEFAULT_JSON_FILE}" ]; then
+        echo "DEFAULT_JSON_FILE value unset"
+        exit 1
+    fi
+
+    case $action in
+        install-wheel)
+            pip install "${wheels[0]}"
+            container_json_file="/usr/local/share/sambacc/examples/${DEFAULT_JSON_FILE}"
+        ;;
+        install-rpm)
+            dnf install -y "${rpmfiles[0]}"
+            dnf clean all
+            container_json_file="/usr/share/sambacc/examples/${DEFAULT_JSON_FILE}"
+        ;;
+        *)
+            echo "no install package(s) found"
+            exit 1
+        ;;
+    esac
+
+    if [ "$container_json_file" ]; then
+        ln -sf "$container_json_file" /etc/samba/container.json
+    fi
+}

--- a/images/server/Containerfile.centos
+++ b/images/server/Containerfile.centos
@@ -37,6 +37,7 @@ RUN /usr/local/bin/install-packages.sh \
 COPY --from=builder \
     /srv/dist/latest \
     /tmp/sambacc-dist-latest
+COPY .common/install-sambacc-common.sh /usr/local/bin/install-sambacc-common.sh
 COPY install-sambacc.sh /usr/local/bin/install-sambacc.sh
 RUN /usr/local/bin/install-sambacc.sh \
     "/tmp/sambacc-dist-latest" \

--- a/images/server/Containerfile.fedora
+++ b/images/server/Containerfile.fedora
@@ -32,6 +32,7 @@ RUN /usr/local/bin/install-packages.sh \
 COPY --from=builder \
     /srv/dist/latest \
     /tmp/sambacc-dist-latest
+COPY .common/install-sambacc-common.sh /usr/local/bin/install-sambacc-common.sh
 COPY install-sambacc.sh /usr/local/bin/install-sambacc.sh
 RUN /usr/local/bin/install-sambacc.sh \
     "/tmp/sambacc-dist-latest" \

--- a/images/server/install-sambacc.sh
+++ b/images/server/install-sambacc.sh
@@ -2,48 +2,7 @@
 
 set -ex
 
-wheeldir="$1"
-if ! [ -d "${wheeldir}" ]; then
-    echo "no directory: ${wheeldir}"
-    exit 2
-fi
-
-mapfile -d '' wheels < \
-    <(find "${wheeldir}" -type f -name 'sambacc-*.whl' -print0)
-mapfile -d '' rpmfiles < \
-    <(find "${wheeldir}" -type f -name '*sambacc-*.noarch.rpm' -print0)
-
-
-if [ "${#wheels[@]}" -gt 1 ]; then
-    echo "more than one wheel file found"
-    exit 1
-elif [ "${#wheels[@]}" -eq 1 ]; then
-    action=install-wheel
-fi
-
-if [ "${#rpmfiles[@]}" -gt 1 ]; then
-    echo "more than one rpm file found"
-    exit 1
-elif [ "${#rpmfiles[@]}" -eq 1 ]; then
-    action=install-rpm
-fi
-
-case $action in
-    install-wheel)
-        pip install "${wheels[0]}"
-        container_json_file="/usr/local/share/sambacc/examples/minimal.json"
-    ;;
-    install-rpm)
-        dnf install -y "${rpmfiles[0]}"
-        dnf clean all
-        container_json_file="/usr/share/sambacc/examples/minimal.json"
-    ;;
-    *)
-        echo "no install package(s) found"
-        exit 1
-    ;;
-esac
-
-if [ "$container_json_file" ]; then
-    ln -sf "$container_json_file" /etc/samba/container.json
-fi
+# shellcheck source=images/common/install-sambacc-common.sh
+. install-sambacc-common.sh
+export DEFAULT_JSON_FILE=minimal.json
+install_sambacc "$@"


### PR DESCRIPTION
The script to install sambacc was a near copy-n-paste from server to ad-server. Any future changes to one script has to be copied back to the other. This change tries to simplify the install of sambacc by creating a common script and then sourcing it from each specific install script.

Other simplifications too.