### PR TITLE
ad-server: add tdb-tools to installed packages

### DIFF
--- a/images/ad-server/Containerfile.opensuse
+++ b/images/ad-server/Containerfile.opensuse
@@ -26,6 +26,7 @@ RUN zypper --non-interactive install --no-recommends \
   python3-jsonschema \
   samba-python3 \
   python3-pyxattr \
+  tdb-tools \
   samba-ad-dc \
   procps \
   samba-client \


### PR DESCRIPTION
Including tdb tools will permit the use of programs like tdbbackup to be used from within the AD DC container.

This was added to the Fedora container, so let's add it to the openSUSE container for consistency.