### PR TITLE
Add gitlint support to samba-container

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -34,6 +34,19 @@ jobs:
     - name: Run static check tools
       run: make check SHELLCHECK=$HOME/bin/shellcheck
 
+  check-commits:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Ensure branches
+        run: git fetch
+      - name: Lint git commit messages
+        run: make check-gitlint
+
   build-server:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -19,20 +19,10 @@ jobs:
     - uses: actions/checkout@v3
     # We need a newer version of shellcheck to avoid problems with the
     # relative imports. Our scripts work on v0.7.2 and up but not the
-    # v0.7.0 preinstalled in the ubutnu image
-    - name: Update shellcheck
-      run: |
-        shellcheck_version="v0.8.0"
-        url="https://github.com/koalaman/shellcheck/releases/download/${shellcheck_version}/shellcheck-${shellcheck_version}.linux.x86_64.tar.xz"
-        curl -Lo /tmp/shellcheck.tar.xz "$url"
-        mkdir /tmp/shellcheck
-        tar -xf /tmp/shellcheck.tar.xz -C /tmp/shellcheck
-        mkdir -p ~/bin
-        install -m0755 /tmp/shellcheck/shellcheck-${shellcheck_version}/shellcheck  ~/bin/shellcheck
-    - name: Show shellcheck version
-      run: $HOME/bin/shellcheck --version
+    # v0.7.0 preinstalled in the ubutnu image. We can force a local
+    # install by expliclity setting SHELLCHECK to `$ALT_BIN/shellcheck`
     - name: Run static check tools
-      run: make check SHELLCHECK=$HOME/bin/shellcheck
+      run: make check SHELLCHECK=$PWD/.bin/shellcheck
 
   check-commits:
     runs-on: ubuntu-latest

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,119 @@
+# Edit this file as you like.
+#
+# All these sections are optional. Each section with the exception of [general] represents
+# one rule and each key in it is an option for that specific rule.
+#
+# Rules and sections can be referenced by their full name or by id. For example
+# section "[body-max-line-length]" could also be written as "[B1]". Full section names are
+# used in here for clarity.
+#
+[general]
+# Ignore certain rules, this example uses both full name and id
+# ignore=title-trailing-punctuation, T3
+
+# verbosity should be a value between 1 and 3, the commandline -v flags take precedence over this
+verbosity=3
+
+# By default gitlint will ignore merge, revert, fixup and squash commits.
+ignore-merge-commits=true
+# ignore-revert-commits=true
+# ignore-fixup-commits=true
+# ignore-squash-commits=true
+
+# Ignore any data send to gitlint via stdin
+# ignore-stdin=true
+
+# Fetch additional meta-data from the local repository when manually passing a
+# commit message to gitlint via stdin or --commit-msg. Disabled by default.
+# staged=true
+
+# Enable debug mode (prints more output). Disabled by default.
+# debug=true
+
+# Enable community contributed rules
+# See http://jorisroovers.github.io/gitlint/contrib_rules for details
+# contrib=contrib-body-requires-signed-off-by
+
+# Set the extra-path where gitlint will search for user defined rules
+# See http://jorisroovers.github.io/gitlint/user_defined_rules for details
+# extra-path=examples/
+
+# This is an example of how to configure the "title-max-length" rule and
+# set the line-length it enforces to 80
+[title-max-length]
+line-length=72
+
+# Conversely, you can also enforce minimal length of a title with the
+# "title-min-length" rule:
+# [title-min-length]
+# min-length=5
+
+[title-must-not-contain-word]
+# Comma-separated list of words that should not occur in the title. Matching is case
+# insensitive. It's fine if the keyword occurs as part of a larger word (so "WIPING"
+# will not cause a violation, but "WIP: my title" will.
+words=wip,WIP
+
+[title-match-regex]
+# python-style regex that the commit-msg title must match
+# Note that the regex can contradict with other rules if not used correctly
+# (e.g. title-must-not-contain-word).
+regex=^.*
+
+# [body-max-line-length]
+# line-length=72
+
+# [body-min-length]
+# min-length=5
+
+# [body-is-missing]
+# Whether to ignore this rule on merge commits (which typically only have a title)
+# default = True
+# ignore-merge-commits=false
+
+# [body-changed-file-mention]
+# List of files that need to be explicitly mentioned in the body when they are changed
+# This is useful for when developers often erroneously edit certain files or git submodules.
+# By specifying this rule, developers can only change the file when they explicitly reference
+# it in the commit message.
+# files=gitlint/rules.py,README.md
+
+# [body-match-regex]
+# python-style regex that the commit-msg body must match.
+# E.g. body must end in My-Commit-Tag: foo
+# regex=My-Commit-Tag: foo$
+
+# [author-valid-email]
+# python-style regex that the commit author email address must match.
+# For example, use the following regex if you only want to allow email addresses from foo.com
+# regex=[^@]+@foo.com
+
+# [ignore-by-title]
+# Ignore certain rules for commits of which the title matches a regex
+# E.g. Match commit titles that start with "Release"
+# regex=^Release(.*)
+
+# Ignore certain rules, you can reference them by their id or by their full name
+# Use 'all' to ignore all rules
+# ignore=T1,body-min-length
+
+# [ignore-by-body]
+# Ignore certain rules for commits of which the body has a line that matches a regex
+# E.g. Match bodies that have a line that that contain "release"
+# regex=(.*)release(.*)
+#
+# Ignore certain rules, you can reference them by their id or by their full name
+# Use 'all' to ignore all rules
+# ignore=T1,body-min-length
+
+# [ignore-body-lines]
+# Ignore certain lines in a commit body that match a regex.
+# E.g. Ignore all lines that start with 'Co-Authored-By'
+# regex=^Co-Authored-By
+
+# This is a contrib rule - a community contributed rule. These are disabled by default.
+# You need to explicitly enable them one-by-one by adding them to the "contrib" option
+# under [general] section above.
+# [contrib-title-conventional-commits]
+# Specify allowed commit types. For details see: https://www.conventionalcommits.org/
+# types = bugfix,user-story,epic

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ endif
 BUILD_CMD:=$(CONTAINER_CMD) build $(BUILD_OPTS)
 PUSH_CMD:=$(CONTAINER_CMD) push $(PUSH_OPTS)
 SHELLCHECK:=shellcheck
+GITLINT:=gitlint
 
 SERVER_DIR:=images/server
 AD_SERVER_DIR:=images/ad-server
@@ -252,6 +253,10 @@ check-shell-scripts:
 	$(SHELLCHECK) -P tests/ -eSC2181 -fgcc $$(find $(ROOT_DIR) -name "*.sh")
 .PHONY: check-shell-scripts
 
+# not included in check to not disrupt wip branches
+check-gitlint:
+	$(GITLINT) -C .gitlint --commits origin/master.. lint
+.PHONY: check-gitlint
 
 ### Mics. Rules ###
 

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# helper script to install build auxiliary tools in local directory
+#
+# usage:
+#   install-tools.sh --<tool-name> <alt_bin>
+#
+#
+set -e
+
+_ensure_alt_bin() {
+	mkdir -p "${ALT_BIN}"
+}
+
+_require_py() {
+    if [ -z "$PY_CMD" ]; then
+        echo "error: python3 command required, but not found" >&2
+        echo "(set PY_CMD to specify python command)" >&2
+        exit 5
+    fi
+}
+
+_install_gitlint() {
+    _require_py
+    _ensure_alt_bin
+    "${PY_CMD}" -m venv "${ALT_BIN}/.py"
+    "${ALT_BIN}/.py/bin/pip" install "gitlint==${GITLINT_VER}"
+    installed_to="${ALT_BIN}/gitlint"
+    ln -s "${ALT_BIN}/.py/bin/gitlint" "${installed_to}"
+}
+
+_install_shellcheck() {
+    installed_to="${ALT_BIN}/shellcheck"
+    local url="https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VER}/shellcheck-${SHELLCHECK_VER}.linux.x86_64.tar.xz"
+    tmpdir="$(mktemp -d)"
+    _ensure_alt_bin
+    curl -Lo "${tmpdir}/shellcheck.tar.xz" "$url"
+    mkdir "${tmpdir}/shellcheck"
+    tar -xf "${tmpdir}/shellcheck.tar.xz" -C "${tmpdir}/shellcheck"
+    mkdir -p ~/bin
+    install -m0755 "${tmpdir}/shellcheck/shellcheck-${SHELLCHECK_VER}/shellcheck" "${installed_to}"
+    rm -rf "${tmpdir}"
+}
+
+
+GITLINT_VER="0.19.1"
+SHELLCHECK_VER="v0.8.0"
+
+
+if [ -z "$PY_CMD" ]; then
+    if ! PY_CMD="$(command -v python3)"; then
+        echo "warning: failed to find python3 command" >&2
+    fi
+fi
+
+ALT_BIN="$(realpath "${2:-.bin}")"
+case "$1" in
+    --gitlint)
+        if command -v "${ALT_BIN}/gitlint" 2>/dev/null; then
+            exit 0
+        fi
+        _install_gitlint 1>&2
+        echo "${installed_to}"
+    ;;
+    --shellcheck)
+        if command -v "${ALT_BIN}/shellcheck" 2>/dev/null; then
+            exit 0
+        fi
+        _install_shellcheck 1>&2
+        echo "${installed_to}"
+    ;;
+    *)
+        echo "usage: $0 --<tool-name> [<ALT_BIN>]"
+        echo ""
+        echo "available tools:"
+        echo "  --gitlint"
+        echo "  --shellcheck"
+    ;;
+esac


### PR DESCRIPTION
Fixes: #121

I'm perfectly happy with the first commit in this series. 

Everything including and after adding the 'install-tools.sh' I'm a bit iffy on. I tried multiple approaches and nothing pleased me. This current version is based on the workflow we have in samba-container where if the makefile determines a prerequisite tool is not present it tries to locally install one in the `.bin` subdir under the repo root.  Unlike the samba-operator version I tried really hard to avoid adding a lot of boilerplate to the makefie now and in the future and used some pattern matching to avoid it. Still, I'm not exactly thrilled with the implementation, but it was working OK for me.

