### PR TITLE
install sambacc from COPR

### DIFF
--- a/images/ad-server/Containerfile.fedora
+++ b/images/ad-server/Containerfile.fedora
@@ -1,14 +1,3 @@
-FROM quay.io/samba.org/sambacc:latest AS builder
-ARG SAMBACC_VER=master
-ARG SAMBACC_REPO=https://github.com/samba-in-kubernetes/sambacc
-
-# The SAMBACC_VER value controls what version of sambacc we'll be building.
-# This can be a branch name, a tag, or a version hash.  When building tagged
-# versions of samba-containers we should use a sambacc tag.
-# SAMBACC_DISTNAME controls where the script will output a built wheel.
-RUN SAMBACC_DISTNAME=latest \
-    /usr/local/bin/build.sh ${SAMBACC_VER} ${SAMBACC_REPO}
-
 FROM registry.fedoraproject.org/fedora:36
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
@@ -27,14 +16,16 @@ RUN /usr/local/bin/install-packages.sh \
     "${SAMBA_VERSION_SUFFIX}" \
     "${INSTALL_CUSTOM_REPO}"
 
-COPY --from=builder \
-    /srv/dist/latest \
-    /tmp/sambacc-dist-latest
+# If you want to install a custom version of sambacc into this image mount
+# a directory containing a sambacc RPM, or a sambacc wheel, or a .repo
+# file at /tmp/sambacc-dist-latest
+# If the directory is empty the script automatically falls back to using
+# the latest continuously built RPM from our sambacc COPR:
+# https://copr.fedorainfracloud.org/coprs/phlogistonjohn/sambacc
 COPY .common/install-sambacc-common.sh /usr/local/bin/install-sambacc-common.sh
 COPY install-sambacc.sh /usr/local/bin/install-sambacc.sh
 RUN /usr/local/bin/install-sambacc.sh \
-    "/tmp/sambacc-dist-latest" \
-    && rm -rf /tmp/sambacc-dist-latest
+    "/tmp/sambacc-dist-latest"
 
 
 ENV SAMBACC_CONFIG="/etc/samba/container.json:/etc/samba/users.json"

--- a/images/common/install-sambacc-common.sh
+++ b/images/common/install-sambacc-common.sh
@@ -52,8 +52,18 @@ install_sambacc() {
             container_json_file="/usr/share/sambacc/examples/${DEFAULT_JSON_FILE}"
         ;;
         install-from-copr-repo)
+            # shellcheck disable=SC1091
+            OS_BASE="$(. /etc/os-release && echo "${ID}")"
             dnf install -y 'dnf-command(copr)'
-            dnf copr enable -y phlogistonjohn/sambacc
+
+            copr_args=("phlogistonjohn/sambacc")
+            if [ "$OS_BASE" = centos ]; then
+                # centos needs a little help determining what repository
+                # within the copr to use. By default it only wants
+                # to add `epel-9-$arch`.
+                copr_args+=("centos-stream+epel-next-9-$(uname -p)")
+            fi
+            dnf copr enable -y "${copr_args[@]}"
             dnf install -y python3-sambacc
             dnf clean all
             container_json_file="/usr/share/sambacc/examples/${DEFAULT_JSON_FILE}"

--- a/images/common/install-sambacc-common.sh
+++ b/images/common/install-sambacc-common.sh
@@ -3,12 +3,11 @@
 install_sambacc() {
     local distdir="$1"
     if ! [ -d "${distdir}" ]; then
-        echo "no directory: ${distdir}"
-        exit 2
+        echo "warning: no directory: ${distdir}" >&2
+    else
+        mapfile -d '' artifacts < \
+            <(find "${distdir}" -type f -print0)
     fi
-
-    mapfile -d '' artifacts < \
-        <(find "${distdir}" -type f -print0)
 
     local wheels=()
     local rpmfiles=()
@@ -22,6 +21,7 @@ install_sambacc() {
     done
 
 
+    local action=install-from-copr-repo
     if [ "${#wheels[@]}" -gt 1 ]; then
         echo "more than one wheel file found"
         exit 1
@@ -48,6 +48,13 @@ install_sambacc() {
         ;;
         install-rpm)
             dnf install -y "${rpmfiles[0]}"
+            dnf clean all
+            container_json_file="/usr/share/sambacc/examples/${DEFAULT_JSON_FILE}"
+        ;;
+        install-from-copr-repo)
+            dnf install -y 'dnf-command(copr)'
+            dnf copr enable -y phlogistonjohn/sambacc
+            dnf install -y python3-sambacc
             dnf clean all
             container_json_file="/usr/share/sambacc/examples/${DEFAULT_JSON_FILE}"
         ;;

--- a/images/common/install-sambacc-common.sh
+++ b/images/common/install-sambacc-common.sh
@@ -7,10 +7,19 @@ install_sambacc() {
         exit 2
     fi
 
-    mapfile -d '' wheels < \
-        <(find "${distdir}" -type f -name 'sambacc-*.whl' -print0)
-    mapfile -d '' rpmfiles < \
-        <(find "${distdir}" -type f -name '*sambacc-*.noarch.rpm' -print0)
+    mapfile -d '' artifacts < \
+        <(find "${distdir}" -type f -print0)
+
+    local wheels=()
+    local rpmfiles=()
+    for artifact in "${artifacts[@]}" ; do
+        if [[ ${artifact} =~ sambacc.*\.whl$ ]]; then
+            wheels+=("${artifact}")
+        fi
+        if [[ ${artifact} =~ python.?-sambacc-.*\.noarch\.rpm$ ]]; then
+            rpmfiles+=("${artifact}")
+        fi
+    done
 
 
     if [ "${#wheels[@]}" -gt 1 ]; then
@@ -21,7 +30,7 @@ install_sambacc() {
     fi
 
     if [ "${#rpmfiles[@]}" -gt 1 ]; then
-        echo "more than one rpm file found"
+        echo "more than one sambacc rpm file found"
         exit 1
     elif [ "${#rpmfiles[@]}" -eq 1 ]; then
         action=install-rpm

--- a/images/common/install-sambacc-common.sh
+++ b/images/common/install-sambacc-common.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 install_sambacc() {
-    wheeldir="$1"
-    if ! [ -d "${wheeldir}" ]; then
-        echo "no directory: ${wheeldir}"
+    local distdir="$1"
+    if ! [ -d "${distdir}" ]; then
+        echo "no directory: ${distdir}"
         exit 2
     fi
 
     mapfile -d '' wheels < \
-        <(find "${wheeldir}" -type f -name 'sambacc-*.whl' -print0)
+        <(find "${distdir}" -type f -name 'sambacc-*.whl' -print0)
     mapfile -d '' rpmfiles < \
-        <(find "${wheeldir}" -type f -name '*sambacc-*.noarch.rpm' -print0)
+        <(find "${distdir}" -type f -name '*sambacc-*.noarch.rpm' -print0)
 
 
     if [ "${#wheels[@]}" -gt 1 ]; then

--- a/images/server/Containerfile.centos
+++ b/images/server/Containerfile.centos
@@ -1,18 +1,3 @@
-FROM quay.io/samba.org/sambacc:latest AS builderscript
-FROM quay.io/centos/centos:stream9 as builder
-COPY --from=builderscript /usr/local/bin/build.sh /usr/local/bin/build.sh
-RUN /usr/local/bin/build.sh --install -v
-
-ARG SAMBACC_VER=master
-ARG SAMBACC_REPO=https://github.com/samba-in-kubernetes/sambacc
-
-# The SAMBACC_VER value controls what version of sambacc we'll be building.
-# This can be a branch name, a tag, or a version hash.  When building tagged
-# versions of samba-containers we should use a sambacc tag.
-# SAMBACC_DISTNAME controls where the script will output a built wheel.
-RUN SAMBACC_DISTNAME=latest \
-    /usr/local/bin/build.sh ${SAMBACC_VER} ${SAMBACC_REPO}
-
 FROM quay.io/centos/centos:stream9
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
@@ -34,14 +19,16 @@ RUN /usr/local/bin/install-packages.sh \
     "${SAMBA_VERSION_SUFFIX}" \
     "${INSTALL_CUSTOM_REPO}"
 
-COPY --from=builder \
-    /srv/dist/latest \
-    /tmp/sambacc-dist-latest
+# If you want to install a custom version of sambacc into this image mount
+# a directory containing a sambacc RPM, or a sambacc wheel, or a .repo
+# file at /tmp/sambacc-dist-latest
+# If the directory is empty the script automatically falls back to using
+# the latest continuously built RPM from our sambacc COPR:
+# https://copr.fedorainfracloud.org/coprs/phlogistonjohn/sambacc
 COPY .common/install-sambacc-common.sh /usr/local/bin/install-sambacc-common.sh
 COPY install-sambacc.sh /usr/local/bin/install-sambacc.sh
 RUN /usr/local/bin/install-sambacc.sh \
-    "/tmp/sambacc-dist-latest" \
-    && rm -rf /tmp/sambacc-dist-latest
+    "/tmp/sambacc-dist-latest"
 
 
 VOLUME ["/share"]

--- a/images/server/Containerfile.fedora
+++ b/images/server/Containerfile.fedora
@@ -1,14 +1,3 @@
-FROM quay.io/samba.org/sambacc:latest AS builder
-ARG SAMBACC_VER=master
-ARG SAMBACC_REPO=https://github.com/samba-in-kubernetes/sambacc
-
-# The SAMBACC_VER value controls what version of sambacc we'll be building.
-# This can be a branch name, a tag, or a version hash.  When building tagged
-# versions of samba-containers we should use a sambacc tag.
-# SAMBACC_DISTNAME controls where the script will output a built wheel.
-RUN SAMBACC_DISTNAME=latest \
-    /usr/local/bin/build.sh ${SAMBACC_VER} ${SAMBACC_REPO}
-
 FROM registry.fedoraproject.org/fedora:36
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
@@ -29,14 +18,16 @@ RUN /usr/local/bin/install-packages.sh \
     "${SAMBA_VERSION_SUFFIX}" \
     "${INSTALL_CUSTOM_REPO}"
 
-COPY --from=builder \
-    /srv/dist/latest \
-    /tmp/sambacc-dist-latest
+# If you want to install a custom version of sambacc into this image mount
+# a directory containing a sambacc RPM, or a sambacc wheel, or a .repo
+# file at /tmp/sambacc-dist-latest
+# If the directory is empty the script automatically falls back to using
+# the latest continuously built RPM from our sambacc COPR:
+# https://copr.fedorainfracloud.org/coprs/phlogistonjohn/sambacc
 COPY .common/install-sambacc-common.sh /usr/local/bin/install-sambacc-common.sh
 COPY install-sambacc.sh /usr/local/bin/install-sambacc.sh
 RUN /usr/local/bin/install-sambacc.sh \
-    "/tmp/sambacc-dist-latest" \
-    && rm -rf /tmp/sambacc-dist-latest
+    "/tmp/sambacc-dist-latest"
 
 
 VOLUME ["/share"]


### PR DESCRIPTION
Depends on: #118

Update the sambacc install script to default to using our new COPR by default if there's no "distdir" provided. Switch the server fedora, server centos, and ad-server fedora container files to use the COPR by no longer building the RPM in a builder image.