### PR TITLE
Update fedora image bases to version 37

### DIFF
--- a/images/ad-server/Containerfile.fedora
+++ b/images/ad-server/Containerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:36
+FROM registry.fedoraproject.org/fedora:37
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
 ARG SAMBA_SPECIFICS=

--- a/images/client/Containerfile.fedora
+++ b/images/client/Containerfile.fedora
@@ -1,6 +1,6 @@
 # Copyright 2020 Michael Adam
 
-FROM registry.fedoraproject.org/fedora:36
+FROM registry.fedoraproject.org/fedora:37
 
 MAINTAINER Michael Adam <obnox@samba.org>
 

--- a/images/server/Containerfile.fedora
+++ b/images/server/Containerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:36
+FROM registry.fedoraproject.org/fedora:37
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
 ARG SAMBA_SPECIFICS=daemon_cli_debug_output,ctdb_leader_admin_command


### PR DESCRIPTION
Depends on: #127 

Fixes: #111 

With the recent release of Fedora 38, fedora 36 is now EOL. We should move to a still-supported version.

Additionally, this should move the container images to a version where all optional features of sambacc work. This should be automatically activated by the sambacc RPM packages `Recommends` lines on fc37 and later.