### PR TITLE
Add preliminary support for building arm64 images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,10 +307,11 @@ clean:
 _img_build: $(DIR)/.common
 	$(BUILD_CMD) \
 		$(BUILD_ARGS) \
+		$(if $(filter-out $(HOST_ARCH),$(BUILD_ARCH)),--arch $(BUILD_ARCH)) \
 		$(EXTRA_BUILD_ARGS) \
 		--tag $(SHORT_NAME) \
 		--tag $(REPO_NAME) \
-		--tag $(call build_fqin,$(call get_imagename,$(SHORT_NAME)),$(call get_pkgsource,$(SHORT_NAME)),$(SRC_OS_NAME),$(HOST_ARCH),$(EXTRA_TAG)) \
+		--tag $(call build_fqin,$(call get_imagename,$(SHORT_NAME)),$(call get_pkgsource,$(SHORT_NAME)),$(SRC_OS_NAME),$(if $(BUILD_ARCH),$(BUILD_ARCH),$(HOST_ARCH)),$(EXTRA_TAG)) \
 		-f $(SRC_FILE) \
 		$(DIR)
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(SHORT_NAME) > $(BUILDFILE)

--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ check-gitlint: $(filter $(ALT_BIN)%,$(GITLINT))
 	$(GITLINT) -C .gitlint --commits origin/master.. lint
 .PHONY: check-gitlint
 
-### Mics. Rules ###
+### Misc. Rules ###
 
 clean:
 	$(RM) $(BUILDFILE_PREFIX)*

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ AD_SERVER_DIR:=images/ad-server
 CLIENT_DIR:=images/client
 TOOLBOX_DIR:=images/toolbox
 
+OS_NAME=
 SRC_OS_NAME=$(if $(OS_NAME),$(OS_NAME),fedora)
 
 SERVER_SRC_FILE=$(SERVER_DIR)/Containerfile.$(SRC_OS_NAME)
@@ -45,8 +46,6 @@ AD_SERVER_SOURCES=\
 	$(AD_SERVER_DIR)/install-sambacc.sh
 CLIENT_SRC_FILE=$(CLIENT_DIR)/Containerfile.$(SRC_OS_NAME)
 TOOLBOX_SRC_FILE=$(TOOLBOX_DIR)/Containerfile.$(SRC_OS_NAME)
-
-OS_NAME=
 
 
 BUILDFILE_PREFIX=.build


### PR DESCRIPTION
Aside from a couple of cleanup commits this series contains two significant changes:
1. It adds a new form of image name/tag I've nicknamed the "fully qualified image name" that is a long tag containing a bunch of details about the image - mainly package source (default or nightly), base os, and architecture. Plus developers can add a final optional extra value when hacking on things.
2. Add a BUILD_ARCH variable that you can pass to make to have it build an architecture other than the native one.

use it like `make BUILD_ARCH=arm64` (assuming an amd64 machine).


Note that this uses a standard way to request arm64 (or other) architectures using     the `--arch` flag to podman (untested on docker (yet)). This makefile change does *nothing* to     attempt to make that flag work on a particular system. If the flag     works then this makefile will build the image and save it, with
    the correct arch recorded in the recently added "fully qualified     image name".

This change also does nothing with with image, no tests, no creating     of manifest lists to create a something pushable, nothing.     I tried to start some of that, which lead to me attempting to lightly
    reorganize the makefile, which lead me to attempting to heavily     reorganize the makefile, and that was a huge mess and a terrible slog     and the delta would have been impossible to follow. Thus I'm now     creating the smallest delta I can think of that still gets the work     to support arm64 builds started.

Future PRs will attempt to further use the FQIN to disambiguate the image builds so that building images won't be so much based on variables and buildfiles that overlap. As well as beginning the work to make this testable(?) and pushable.
