### PR TITLE
Add yamllint checking

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -2,9 +2,9 @@ name: Samba Container Image CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   schedule:
     - cron: '0 2 * * *'
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .build.nightly.server
 .build.nightly.ad-server
 .common
+.bin

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,36 @@
+---
+extends: default
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+ignore: |
+  vendor
+rules:
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
+  comments: disable
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start: disable
+  empty-lines:
+    max-start: 1
+    level: warning
+  empty-values: disable
+  hyphens: enable
+  indentation:
+    level: warning
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable
+  new-line-at-end-of-file: enable
+  new-lines: enable
+  octal-values: enable
+  quoted-strings: disable
+  trailing-spaces: enable
+  truthy:
+    level: warning
+    allowed-values: ['true', 'false', 'on']

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ PUSH_CMD:=$(CONTAINER_CMD) push $(PUSH_OPTS)
 ALT_BIN=$(CURDIR)/.bin
 SHELLCHECK=$(shell command -v shellcheck || echo $(ALT_BIN)/shellcheck)
 GITLINT=$(shell command -v gitlint || echo $(ALT_BIN)/gitlint)
-
+YAMLLINT_CMD=$(shell command -v yamllint || echo $(ALT_BIN)/yamllint)
 COMMON_DIR:=images/common
 SERVER_DIR:=images/server
 AD_SERVER_DIR:=images/ad-server
@@ -273,13 +273,17 @@ test-nightly-server: build-nightly-server
 
 ### Check Rules: static checks, quality tools ###
 
-check: check-shell-scripts
+check: check-shell-scripts check-yaml
 .PHONY: check
-
 # rule requires shellcheck and find to run
 check-shell-scripts: $(filter $(ALT_BIN)%,$(SHELLCHECK))
 	$(SHELLCHECK) -P tests/ -eSC2181 -fgcc $$(find $(ROOT_DIR) -name "*.sh")
 .PHONY: check-shell-scripts
+
+
+check-yaml: $(filter $(ALT_BIN)%,$(YAMLLINT_CMD))
+	$(YAMLLINT_CMD) -c $(CURDIR)/.yamllint.yaml $(CURDIR)
+.PHONY: check-yaml
 
 # not included in check to not disrupt wip branches
 check-gitlint: $(filter $(ALT_BIN)%,$(GITLINT))

--- a/Makefile
+++ b/Makefile
@@ -290,13 +290,6 @@ check-gitlint: $(filter $(ALT_BIN)%,$(GITLINT))
 	$(GITLINT) -C .gitlint --commits origin/master.. lint
 .PHONY: check-gitlint
 
-### Misc. Rules ###
-
-clean: clean-buildfiles clean-altbin
-clean-buildfiles:
-	$(RM) $(BUILDFILE_PREFIX)*
-.PHONY: clean clean-buildfiles
-
 # _img_build is an "internal" rule to make the building of samba-container
 # images regular and more "self documenting". A makefile.foo that includes
 # this Makefile can add build rules using _img_build as a building block.
@@ -329,6 +322,16 @@ $(DIR)/.common: $(COMMON_DIR)
 $(ALT_BIN)/%:
 	$(CURDIR)/hack/install-tools.sh --$* $(ALT_BIN)
 
+
+
+### Misc. Rules ###
+
+clean: clean-buildfiles clean-altbin
+.PHONY: clean
+clean-buildfiles:
+	$(RM) $(BUILDFILE_PREFIX)*
+.PHONY:  clean-buildfiles
 clean-altbin:
 	$(RM) -r $(ALT_BIN)
 .PHONY: clean-altbin
+

--- a/Makefile
+++ b/Makefile
@@ -292,9 +292,10 @@ check-gitlint: $(filter $(ALT_BIN)%,$(GITLINT))
 
 ### Misc. Rules ###
 
-clean:
+clean: clean-buildfiles clean-altbin
+clean-buildfiles:
 	$(RM) $(BUILDFILE_PREFIX)*
-.PHONY: clean
+.PHONY: clean clean-buildfiles
 
 # _img_build is an "internal" rule to make the building of samba-container
 # images regular and more "self documenting". A makefile.foo that includes

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -52,7 +52,7 @@ if [ -z "$PY_CMD" ]; then
     fi
 fi
 
-ALT_BIN="$(realpath "${2:-.bin}")"
+ALT_BIN="${2:-.bin}"
 case "$1" in
     --gitlint)
         if command -v "${ALT_BIN}/gitlint" 2>/dev/null; then

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -19,6 +19,15 @@ _require_py() {
     fi
 }
 
+_install_yamllint() {
+    _require_py
+    _ensure_alt_bin
+    "${PY_CMD}" -m venv "${ALT_BIN}/.py"
+    "${ALT_BIN}/.py/bin/pip" install "yamllint"
+    installed_to="${ALT_BIN}/yamllint"
+    ln -s "${ALT_BIN}/.py/bin/yamllint" "${installed_to}"
+}
+
 _install_gitlint() {
     _require_py
     _ensure_alt_bin
@@ -54,14 +63,21 @@ fi
 
 ALT_BIN="${2:-.bin}"
 case "$1" in
-    --gitlint)
+    "--yamllint")
+        if command -v "${ALT_BIN}/yamllint" 2>/dev/null; then
+            exit 0
+        fi
+        _install_yamllint 1>&2
+        echo "${installed_to}"
+    ;;
+    "--gitlint")
         if command -v "${ALT_BIN}/gitlint" 2>/dev/null; then
             exit 0
         fi
         _install_gitlint 1>&2
         echo "${installed_to}"
     ;;
-    --shellcheck)
+    "--shellcheck")
         if command -v "${ALT_BIN}/shellcheck" 2>/dev/null; then
             exit 0
         fi
@@ -73,6 +89,7 @@ case "$1" in
         echo ""
         echo "available tools:"
         echo "  --gitlint"
+	echo "  --yamllint"
         echo "  --shellcheck"
     ;;
 esac


### PR DESCRIPTION
This PR adds yaml lint checking to the tests and to the github  CI workflows.
The code is is inspired by but not identical to  the code from samba-operator.

This PR is proposed to allow for easier update of our yamls, e. g. workflow yamls in future PRs. 