### PR TITLE
images: support a SAMBACC_VERSION_SUFFIX to force a sambacc version

### DIFF
--- a/images/ad-server/Containerfile.fedora
+++ b/images/ad-server/Containerfile.fedora
@@ -1,6 +1,7 @@
 FROM registry.fedoraproject.org/fedora:37
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
+ARG SAMBACC_VERSION_SUFFIX=""
 ARG SAMBA_SPECIFICS=
 ARG INSTALL_CUSTOM_REPO=
 
@@ -25,7 +26,8 @@ RUN /usr/local/bin/install-packages.sh \
 COPY .common/install-sambacc-common.sh /usr/local/bin/install-sambacc-common.sh
 COPY install-sambacc.sh /usr/local/bin/install-sambacc.sh
 RUN /usr/local/bin/install-sambacc.sh \
-    "/tmp/sambacc-dist-latest"
+    "/tmp/sambacc-dist-latest" \
+    "${SAMBACC_VERSION_SUFFIX}"
 
 
 ENV SAMBACC_CONFIG="/etc/samba/container.json:/etc/samba/users.json"

--- a/images/common/install-sambacc-common.sh
+++ b/images/common/install-sambacc-common.sh
@@ -2,6 +2,7 @@
 
 install_sambacc() {
     local distdir="$1"
+    local sambacc_version_suffix="$2"
     if ! [ -d "${distdir}" ]; then
         echo "warning: no directory: ${distdir}" >&2
     else
@@ -65,7 +66,7 @@ install_sambacc() {
         install-from-repo)
             local tgt="${repofiles[0]}"
             cp "${tgt}" /etc/yum.repos.d/"$(basename "${tgt}")"
-            dnf install -y python3-sambacc
+            dnf install -y "python3-sambacc${sambacc_version_suffix}"
             dnf clean all
             container_json_file="/usr/share/sambacc/examples/${DEFAULT_JSON_FILE}"
         ;;
@@ -82,7 +83,7 @@ install_sambacc() {
                 copr_args+=("centos-stream+epel-next-9-$(uname -p)")
             fi
             dnf copr enable -y "${copr_args[@]}"
-            dnf install -y python3-sambacc
+            dnf install -y "python3-sambacc${sambacc_version_suffix}"
             dnf clean all
             container_json_file="/usr/share/sambacc/examples/${DEFAULT_JSON_FILE}"
         ;;

--- a/images/server/Containerfile.centos
+++ b/images/server/Containerfile.centos
@@ -1,6 +1,7 @@
 FROM quay.io/centos/centos:stream9
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
+ARG SAMBACC_VERSION_SUFFIX=""
 ARG SAMBA_SPECIFICS=daemon_cli_debug_output,ctdb_leader_admin_command
 ARG INSTALL_CUSTOM_REPO=
 
@@ -28,7 +29,8 @@ RUN /usr/local/bin/install-packages.sh \
 COPY .common/install-sambacc-common.sh /usr/local/bin/install-sambacc-common.sh
 COPY install-sambacc.sh /usr/local/bin/install-sambacc.sh
 RUN /usr/local/bin/install-sambacc.sh \
-    "/tmp/sambacc-dist-latest"
+    "/tmp/sambacc-dist-latest" \
+    "${SAMBACC_VERSION_SUFFIX}"
 
 
 VOLUME ["/share"]

--- a/images/server/Containerfile.fedora
+++ b/images/server/Containerfile.fedora
@@ -1,6 +1,7 @@
 FROM registry.fedoraproject.org/fedora:37
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
+ARG SAMBACC_VERSION_SUFFIX=""
 ARG SAMBA_SPECIFICS=daemon_cli_debug_output,ctdb_leader_admin_command
 ARG INSTALL_CUSTOM_REPO=
 
@@ -27,7 +28,8 @@ RUN /usr/local/bin/install-packages.sh \
 COPY .common/install-sambacc-common.sh /usr/local/bin/install-sambacc-common.sh
 COPY install-sambacc.sh /usr/local/bin/install-sambacc.sh
 RUN /usr/local/bin/install-sambacc.sh \
-    "/tmp/sambacc-dist-latest"
+    "/tmp/sambacc-dist-latest" \
+    "${SAMBACC_VERSION_SUFFIX}"
 
 
 VOLUME ["/share"]


### PR DESCRIPTION
In the previous release we made sure to "pin" a version of both sambacc and samba. The former was done by an "embedded" build which is something we've moved away from. So this adds back the ability to require a sambacc version in a way more similar to how we previously required a samba version.