### PR TITLE
reformat yaml files to remove yamllint warnings

### DIFF
--- a/examples/kubernetes/pv.yml
+++ b/examples/kubernetes/pv.yml
@@ -12,4 +12,3 @@ spec:
     - ReadWriteOnce
   hostPath:
     path: "/mnt/pv"
-

--- a/examples/kubernetes/pvc.yml
+++ b/examples/kubernetes/pvc.yml
@@ -9,4 +9,3 @@ spec:
   resources:
     requests:
       storage: 1Gi
-

--- a/examples/kubernetes/samba-ad-server-deployment.yml
+++ b/examples/kubernetes/samba-ad-server-deployment.yml
@@ -15,42 +15,42 @@ spec:
         app: samba-ad
     spec:
       containers:
-      - name: samba-ad
-        image: quay.io/samba.org/samba-ad-server:latest
-        securityContext:
-          capabilities:
-            add: ["SYS_ADMIN"]
-        ports:
-        # https://wiki.samba.org/index.php/Samba_AD_DC_Port_Usage
-        - containerPort: 53
-          name: dns
-        - containerPort: 135
-          name: epm
-          protocol: TCP
-        - containerPort: 137
-          name: netbios-ns
-          protocol: UDP
-        - containerPort: 138
-          name: netbios-dgram
-          protocol: UDP
-        - containerPort: 139
-          name: netbios-session
-          protocol: TCP
-        - containerPort: 389
-          name: ldap
-        - containerPort: 445
-          name: smb
-          protocol: TCP
-        - containerPort: 464
-          name: kerberos
-        - containerPort: 636
-          name: ldaps
-          protocol: TCP
-        - containerPort: 3268
-          name: gc
-          protocol: TCP
-        - containerPort: 3269
-          name: gc-ssl
-          protocol: TCP
-        # need 49152-65535 for dynamic RPC ports
-        # but currently not possible to specify ranges
+        - name: samba-ad
+          image: quay.io/samba.org/samba-ad-server:latest
+          securityContext:
+            capabilities:
+              add: ["SYS_ADMIN"]
+          ports:
+            # https://wiki.samba.org/index.php/Samba_AD_DC_Port_Usage
+            - containerPort: 53
+              name: dns
+            - containerPort: 135
+              name: epm
+              protocol: TCP
+            - containerPort: 137
+              name: netbios-ns
+              protocol: UDP
+            - containerPort: 138
+              name: netbios-dgram
+              protocol: UDP
+            - containerPort: 139
+              name: netbios-session
+              protocol: TCP
+            - containerPort: 389
+              name: ldap
+            - containerPort: 445
+              name: smb
+              protocol: TCP
+            - containerPort: 464
+              name: kerberos
+            - containerPort: 636
+              name: ldaps
+              protocol: TCP
+            - containerPort: 3268
+              name: gc
+              protocol: TCP
+            - containerPort: 3269
+              name: gc-ssl
+              protocol: TCP
+              # need 49152-65535 for dynamic RPC ports
+              # but currently not possible to specify ranges

--- a/examples/kubernetes/samba-ctdb-dm-sset.yml
+++ b/examples/kubernetes/samba-ctdb-dm-sset.yml
@@ -119,8 +119,8 @@ metadata:
     app: clustered-samba-swc
 spec:
   ports:
-  - port: 445
-    name: smb
+    - port: 445
+      name: smb
   clusterIP: None
   selector:
     app: clustered-samba-swc
@@ -146,290 +146,290 @@ spec:
           imagePullPolicy: Always
           name: init
           args:
-          - "--config=/etc/samba-container/config.json"
-          - "--id=demo"
-          - "--skip-if-file=/var/lib/ctdb/shared/nodes"
-          - "init"
+            - "--config=/etc/samba-container/config.json"
+            - "--id=demo"
+            - "--skip-if-file=/var/lib/ctdb/shared/nodes"
+            - "init"
           env: []
           securityContext:
             allowPrivilegeEscalation: true
           volumeMounts:
-          - mountPath: "/etc/samba-container"
-            name: samba-container-config
-          - mountPath: "/var/lib/samba"
-            name: samba-state-dir
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
+            - mountPath: "/etc/samba-container"
+              name: samba-container-config
+            - mountPath: "/var/lib/samba"
+              name: samba-state-dir
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
         - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: import
           args:
-          - "--config=/etc/samba-container/config.json"
-          - "--id=demo"
-          - "--skip-if-file=/var/lib/ctdb/shared/nodes"
-          - "import"
+            - "--config=/etc/samba-container/config.json"
+            - "--id=demo"
+            - "--skip-if-file=/var/lib/ctdb/shared/nodes"
+            - "import"
           securityContext:
             allowPrivilegeEscalation: true
           volumeMounts:
-          - mountPath: "/etc/samba-container"
-            name: samba-container-config
-          - mountPath: "/var/lib/samba"
-            name: samba-state-dir
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
+            - mountPath: "/etc/samba-container"
+              name: samba-container-config
+            - mountPath: "/var/lib/samba"
+              name: samba-state-dir
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
         - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: must-join
           args:
-          - "--config=/etc/samba-container/config.json"
-          - "--id=demo"
-          - "--skip-if-file=/var/lib/ctdb/shared/nodes"
-          - "must-join"
-          - "--files"
-          - "--join-file=/etc/join-data/join.json"
+            - "--config=/etc/samba-container/config.json"
+            - "--id=demo"
+            - "--skip-if-file=/var/lib/ctdb/shared/nodes"
+            - "must-join"
+            - "--files"
+            - "--join-file=/etc/join-data/join.json"
           securityContext:
             allowPrivilegeEscalation: true
           volumeMounts:
-          - mountPath: "/etc/samba-container"
-            name: samba-container-config
-          - mountPath: "/var/lib/samba"
-            name: samba-state-dir
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
-          - mountPath: "/etc/join-data"
-            name: samba-join-data
-            readOnly: true
+            - mountPath: "/etc/samba-container"
+              name: samba-container-config
+            - mountPath: "/var/lib/samba"
+              name: samba-state-dir
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
+            - mountPath: "/etc/join-data"
+              name: samba-join-data
+              readOnly: true
         - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb-migrate
           args:
-          - "--config=/etc/samba-container/config.json"
-          - "--id=demo"
-          - "--skip-if-file=/var/lib/ctdb/shared/nodes"
-          - "ctdb-migrate"
-          - "--dest-dir=/var/lib/ctdb/persistent"
+            - "--config=/etc/samba-container/config.json"
+            - "--id=demo"
+            - "--skip-if-file=/var/lib/ctdb/shared/nodes"
+            - "ctdb-migrate"
+            - "--dest-dir=/var/lib/ctdb/persistent"
           env:
-          - name: SAMBACC_CTDB
-            value: "ctdb-is-experimental"
+            - name: SAMBACC_CTDB
+              value: "ctdb-is-experimental"
           securityContext:
             allowPrivilegeEscalation: true
           volumeMounts:
-          - mountPath: "/etc/samba-container"
-            name: samba-container-config
-          - mountPath: "/var/lib/samba"
-            name: samba-state-dir
-          - mountPath: "/var/lib/ctdb/persistent"
-            name: ctdb-persistent
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
+            - mountPath: "/etc/samba-container"
+              name: samba-container-config
+            - mountPath: "/var/lib/samba"
+              name: samba-state-dir
+            - mountPath: "/var/lib/ctdb/persistent"
+              name: ctdb-persistent
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
         - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb-set-node
           args:
-          - "--config=/etc/samba-container/config.json"
-          - "--id=demo"
-          - "ctdb-set-node"
-          - "--hostname=$(HOSTNAME)"
-          - "--take-node-number-from-hostname=after-last-dash"
+            - "--config=/etc/samba-container/config.json"
+            - "--id=demo"
+            - "ctdb-set-node"
+            - "--hostname=$(HOSTNAME)"
+            - "--take-node-number-from-hostname=after-last-dash"
           env:
-          - name: SAMBACC_CTDB
-            value: "ctdb-is-experimental"
-          - name: HOSTNAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
+            - name: SAMBACC_CTDB
+              value: "ctdb-is-experimental"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           securityContext:
             allowPrivilegeEscalation: true
           volumeMounts:
-          - mountPath: "/etc/samba-container"
-            name: samba-container-config
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
-          - mountPath: "/etc/ctdb"
-            name: ctdb-config
+            - mountPath: "/etc/samba-container"
+              name: samba-container-config
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
+            - mountPath: "/etc/ctdb"
+              name: ctdb-config
         - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb-must-have-node
           args:
-          - "--config=/etc/samba-container/config.json"
-          - "--id=demo"
-          - "ctdb-must-have-node"
-          - "--hostname=$(HOSTNAME)"
-          - "--take-node-number-from-hostname=after-last-dash"
+            - "--config=/etc/samba-container/config.json"
+            - "--id=demo"
+            - "ctdb-must-have-node"
+            - "--hostname=$(HOSTNAME)"
+            - "--take-node-number-from-hostname=after-last-dash"
           env:
-          - name: SAMBACC_CTDB
-            value: "ctdb-is-experimental"
-          - name: HOSTNAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
+            - name: SAMBACC_CTDB
+              value: "ctdb-is-experimental"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           securityContext:
             allowPrivilegeEscalation: true
           volumeMounts:
-          - mountPath: "/etc/samba-container"
-            name: samba-container-config
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
-          - mountPath: "/etc/ctdb"
-            name: ctdb-config
+            - mountPath: "/etc/samba-container"
+              name: samba-container-config
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
+            - mountPath: "/etc/ctdb"
+              name: ctdb-config
       containers:
         - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb
           args:
-          - "--config=/etc/samba-container/config.json"
-          - "--id=demo"
-          - "--debug-delay=2"
-          - "run"
-          - "ctdbd"
-          - "--setup=smb_ctdb"
-          - "--setup=ctdb_config"
-          - "--setup=ctdb_etc"
-          - "--setup=ctdb_nodes"
+            - "--config=/etc/samba-container/config.json"
+            - "--id=demo"
+            - "--debug-delay=2"
+            - "run"
+            - "ctdbd"
+            - "--setup=smb_ctdb"
+            - "--setup=ctdb_config"
+            - "--setup=ctdb_etc"
+            - "--setup=ctdb_nodes"
           securityContext:
             capabilities:
               add:
-              - NET_RAW
+                - NET_RAW
           env:
-          - name: SAMBACC_CTDB
-            value: "ctdb-is-experimental"
+            - name: SAMBACC_CTDB
+              value: "ctdb-is-experimental"
           volumeMounts:
-          - mountPath: "/etc/samba-container"
-            name: samba-container-config
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
-          - mountPath: "/var/lib/ctdb/persistent"
-            name: ctdb-persistent
-          - mountPath: "/var/lib/ctdb/volatile"
-            name: ctdb-volatile
-          - mountPath: "/etc/ctdb"
-            name: ctdb-config
-          - mountPath: "/var/run/ctdb"
-            name: ctdb-sockets-dir
+            - mountPath: "/etc/samba-container"
+              name: samba-container-config
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
+            - mountPath: "/var/lib/ctdb/persistent"
+              name: ctdb-persistent
+            - mountPath: "/var/lib/ctdb/volatile"
+              name: ctdb-volatile
+            - mountPath: "/etc/ctdb"
+              name: ctdb-config
+            - mountPath: "/var/run/ctdb"
+              name: ctdb-sockets-dir
         - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb-manage-nodes
           args:
-          - "--config=/etc/samba-container/config.json"
-          - "--id=demo"
-          - "ctdb-manage-nodes"
-          - "--hostname=$(HOSTNAME)"
-          - "--take-node-number-from-hostname=after-last-dash"
+            - "--config=/etc/samba-container/config.json"
+            - "--id=demo"
+            - "ctdb-manage-nodes"
+            - "--hostname=$(HOSTNAME)"
+            - "--take-node-number-from-hostname=after-last-dash"
           env:
-          - name: SAMBACC_CTDB
-            value: "ctdb-is-experimental"
-          - name: HOSTNAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
+            - name: SAMBACC_CTDB
+              value: "ctdb-is-experimental"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           volumeMounts:
-          - mountPath: "/etc/samba-container"
-            name: samba-container-config
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
-          - mountPath: "/etc/ctdb"
-            name: ctdb-config
-          - mountPath: "/var/run/ctdb"
-            name: ctdb-sockets-dir
+            - mountPath: "/etc/samba-container"
+              name: samba-container-config
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
+            - mountPath: "/etc/ctdb"
+              name: ctdb-config
+            - mountPath: "/var/run/ctdb"
+              name: ctdb-sockets-dir
         - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: smb
           args:
-          - "--config=/etc/samba-container/config.json"
-          - "--id=demo"
-          - "--debug-delay=12"
-          - "run"
-          - "smbd"
-          - "--setup=nsswitch"
-          - "--setup=smb_ctdb"
+            - "--config=/etc/samba-container/config.json"
+            - "--id=demo"
+            - "--debug-delay=12"
+            - "run"
+            - "smbd"
+            - "--setup=nsswitch"
+            - "--setup=smb_ctdb"
           ports:
-          - containerPort: 445
-            protocol: TCP
-            name: "smb"
+            - containerPort: 445
+              protocol: TCP
+              name: "smb"
           securityContext:
             allowPrivilegeEscalation: true
           volumeMounts:
-          - mountPath: "/etc/samba-container"
-            name: samba-container-config
-          - mountPath: "/share"
-            name: samba-share-data
-          - mountPath: "/var/lib/samba"
-            name: samba-state-dir
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
-          - mountPath: "/var/lib/ctdb/persistent"
-            name: ctdb-persistent
-          - mountPath: "/var/lib/ctdb/volatile"
-            name: ctdb-volatile
-          - mountPath: "/etc/ctdb"
-            name: ctdb-config
-          - mountPath: "/var/run/ctdb"
-            name: ctdb-sockets-dir
-          - mountPath: "/run/samba/winbindd"
-            name: samba-sockets-dir
+            - mountPath: "/etc/samba-container"
+              name: samba-container-config
+            - mountPath: "/share"
+              name: samba-share-data
+            - mountPath: "/var/lib/samba"
+              name: samba-state-dir
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
+            - mountPath: "/var/lib/ctdb/persistent"
+              name: ctdb-persistent
+            - mountPath: "/var/lib/ctdb/volatile"
+              name: ctdb-volatile
+            - mountPath: "/etc/ctdb"
+              name: ctdb-config
+            - mountPath: "/var/run/ctdb"
+              name: ctdb-sockets-dir
+            - mountPath: "/run/samba/winbindd"
+              name: samba-sockets-dir
         - image: quay.io/samba.org/samba-server:latest
           name: winbind
           args:
-          - "--config=/etc/samba-container/config.json"
-          - "--id=demo"
-          - "--debug-delay=10"
-          - "run"
-          - "winbindd"
-          - "--setup=nsswitch"
-          - "--setup=smb_ctdb"
+            - "--config=/etc/samba-container/config.json"
+            - "--id=demo"
+            - "--debug-delay=10"
+            - "run"
+            - "winbindd"
+            - "--setup=nsswitch"
+            - "--setup=smb_ctdb"
           securityContext:
             allowPrivilegeEscalation: true
           volumeMounts:
-          - mountPath: "/etc/samba-container"
-            name: samba-container-config
-          - mountPath: "/var/lib/samba"
-            name: samba-state-dir
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
-          - mountPath: "/var/lib/ctdb/persistent"
-            name: ctdb-persistent
-          - mountPath: "/var/lib/ctdb/volatile"
-            name: ctdb-volatile
-          - mountPath: "/etc/ctdb"
-            name: ctdb-config
-          - mountPath: "/var/run/ctdb"
-            name: ctdb-sockets-dir
-          - mountPath: "/run/samba/winbindd"
-            name: samba-sockets-dir
+            - mountPath: "/etc/samba-container"
+              name: samba-container-config
+            - mountPath: "/var/lib/samba"
+              name: samba-state-dir
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
+            - mountPath: "/var/lib/ctdb/persistent"
+              name: ctdb-persistent
+            - mountPath: "/var/lib/ctdb/volatile"
+              name: ctdb-volatile
+            - mountPath: "/etc/ctdb"
+              name: ctdb-config
+            - mountPath: "/var/run/ctdb"
+              name: ctdb-sockets-dir
+            - mountPath: "/run/samba/winbindd"
+              name: samba-sockets-dir
       volumes:
-      # /etc/ctdb
-      - emptyDir: {}
-        name: ctdb-config
-      # /var/lib/ctdb/persistent
-      - emptyDir: {}
-        name: ctdb-persistent
-      # /var/lib/ctdb/volatile
-      - emptyDir: {}
-        name: ctdb-volatile
-      # /var/lib/ctdb/shared
-      - persistentVolumeClaim:
-          claimName: ctdb-shared-swc
-        name: ctdb-shared
-      # /var/run/ctdb
-      - emptyDir:
-          medium: Memory
-        name: ctdb-sockets-dir
-      # /var/lib/samba
-      - emptyDir: {}
-        name: samba-state-dir
-      # /share
-      - persistentVolumeClaim:
-          claimName: samba-share-data-swc
-        name: samba-share-data
-      - emptyDir:
-          medium: Memory
-        name: samba-sockets-dir
-      - configMap:
-          name: samba-container-config-swc
-        name: samba-container-config
-      - secret:
-          secretName: ad-join-secret
-          items:
-          - key: join.json
-            path: join.json
-        name: samba-join-data
+        # /etc/ctdb
+        - emptyDir: {}
+          name: ctdb-config
+        # /var/lib/ctdb/persistent
+        - emptyDir: {}
+          name: ctdb-persistent
+        # /var/lib/ctdb/volatile
+        - emptyDir: {}
+          name: ctdb-volatile
+        # /var/lib/ctdb/shared
+        - persistentVolumeClaim:
+            claimName: ctdb-shared-swc
+          name: ctdb-shared
+        # /var/run/ctdb
+        - emptyDir:
+            medium: Memory
+          name: ctdb-sockets-dir
+        # /var/lib/samba
+        - emptyDir: {}
+          name: samba-state-dir
+        # /share
+        - persistentVolumeClaim:
+            claimName: samba-share-data-swc
+          name: samba-share-data
+        - emptyDir:
+            medium: Memory
+          name: samba-sockets-dir
+        - configMap:
+            name: samba-container-config-swc
+          name: samba-container-config
+        - secret:
+            secretName: ad-join-secret
+            items:
+              - key: join.json
+                path: join.json
+          name: samba-join-data

--- a/examples/kubernetes/samba-ctdb-sset.yml
+++ b/examples/kubernetes/samba-ctdb-sset.yml
@@ -46,8 +46,8 @@ metadata:
     app: clustered-samba
 spec:
   ports:
-  - port: 445
-    name: smb
+    - port: 445
+      name: smb
   clusterIP: None
   selector:
     app: clustered-samba
@@ -73,218 +73,218 @@ spec:
           imagePullPolicy: Always
           name: init
           args:
-          - "--config=/usr/local/share/sambacc/examples/ctdb.json"
-          - "--id=demo"
-          - "--skip-if-file=/var/lib/ctdb/shared/nodes"
-          - "init"
+            - "--config=/usr/local/share/sambacc/examples/ctdb.json"
+            - "--id=demo"
+            - "--skip-if-file=/var/lib/ctdb/shared/nodes"
+            - "init"
           env: []
           securityContext:
             allowPrivilegeEscalation: true
           volumeMounts:
-          - mountPath: "/var/lib/samba"
-            name: samba-state-dir
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
+            - mountPath: "/var/lib/samba"
+              name: samba-state-dir
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
         - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: import
           args:
-          - "--config=/usr/local/share/sambacc/examples/ctdb.json"
-          - "--id=demo"
-          - "--skip-if-file=/var/lib/ctdb/shared/nodes"
-          - "import"
+            - "--config=/usr/local/share/sambacc/examples/ctdb.json"
+            - "--id=demo"
+            - "--skip-if-file=/var/lib/ctdb/shared/nodes"
+            - "import"
           securityContext:
             allowPrivilegeEscalation: true
           volumeMounts:
-          - mountPath: "/var/lib/samba"
-            name: samba-state-dir
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
+            - mountPath: "/var/lib/samba"
+              name: samba-state-dir
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
         - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: import-users
           args:
-          - "--config=/usr/local/share/sambacc/examples/ctdb.json"
-          - "--id=demo"
-          - "--skip-if-file=/var/lib/ctdb/shared/nodes"
-          - "import-users"
+            - "--config=/usr/local/share/sambacc/examples/ctdb.json"
+            - "--id=demo"
+            - "--skip-if-file=/var/lib/ctdb/shared/nodes"
+            - "import-users"
           securityContext:
             allowPrivilegeEscalation: true
           volumeMounts:
-          - mountPath: "/var/lib/samba"
-            name: samba-state-dir
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
+            - mountPath: "/var/lib/samba"
+              name: samba-state-dir
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
         - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb-migrate
           args:
-          - "--config=/usr/local/share/sambacc/examples/ctdb.json"
-          - "--id=demo"
-          - "--skip-if-file=/var/lib/ctdb/shared/nodes"
-          - "ctdb-migrate"
-          - "--dest-dir=/var/lib/ctdb/persistent"
+            - "--config=/usr/local/share/sambacc/examples/ctdb.json"
+            - "--id=demo"
+            - "--skip-if-file=/var/lib/ctdb/shared/nodes"
+            - "ctdb-migrate"
+            - "--dest-dir=/var/lib/ctdb/persistent"
           env:
-          - name: SAMBACC_CTDB
-            value: "ctdb-is-experimental"
+            - name: SAMBACC_CTDB
+              value: "ctdb-is-experimental"
           securityContext:
             allowPrivilegeEscalation: true
           volumeMounts:
-          - mountPath: "/var/lib/samba"
-            name: samba-state-dir
-          - mountPath: "/var/lib/ctdb/persistent"
-            name: ctdb-persistent
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
+            - mountPath: "/var/lib/samba"
+              name: samba-state-dir
+            - mountPath: "/var/lib/ctdb/persistent"
+              name: ctdb-persistent
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
         - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb-set-node
           args:
-          - "--config=/usr/local/share/sambacc/examples/ctdb.json"
-          - "--id=demo"
-          - "ctdb-set-node"
-          - "--hostname=$(HOSTNAME)"
-          - "--take-node-number-from-hostname=after-last-dash"
+            - "--config=/usr/local/share/sambacc/examples/ctdb.json"
+            - "--id=demo"
+            - "ctdb-set-node"
+            - "--hostname=$(HOSTNAME)"
+            - "--take-node-number-from-hostname=after-last-dash"
           env:
-          - name: SAMBACC_CTDB
-            value: "ctdb-is-experimental"
-          - name: HOSTNAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
+            - name: SAMBACC_CTDB
+              value: "ctdb-is-experimental"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           securityContext:
             allowPrivilegeEscalation: true
           volumeMounts:
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
-          - mountPath: "/etc/ctdb"
-            name: ctdb-config
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
+            - mountPath: "/etc/ctdb"
+              name: ctdb-config
         - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb-must-have-node
           args:
-          - "--config=/usr/local/share/sambacc/examples/ctdb.json"
-          - "--id=demo"
-          - "ctdb-must-have-node"
-          - "--hostname=$(HOSTNAME)"
-          - "--take-node-number-from-hostname=after-last-dash"
+            - "--config=/usr/local/share/sambacc/examples/ctdb.json"
+            - "--id=demo"
+            - "ctdb-must-have-node"
+            - "--hostname=$(HOSTNAME)"
+            - "--take-node-number-from-hostname=after-last-dash"
           env:
-          - name: SAMBACC_CTDB
-            value: "ctdb-is-experimental"
-          - name: HOSTNAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
+            - name: SAMBACC_CTDB
+              value: "ctdb-is-experimental"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           securityContext:
             allowPrivilegeEscalation: true
           volumeMounts:
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
-          - mountPath: "/etc/ctdb"
-            name: ctdb-config
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
+            - mountPath: "/etc/ctdb"
+              name: ctdb-config
       containers:
         - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb
           args:
-          - "--config=/usr/local/share/sambacc/examples/ctdb.json"
-          - "--id=demo"
-          - "--debug-delay=2"
-          - "run"
-          - "ctdbd"
-          - "--setup=smb_ctdb"
-          - "--setup=ctdb_config"
-          - "--setup=ctdb_etc"
-          - "--setup=ctdb_nodes"
+            - "--config=/usr/local/share/sambacc/examples/ctdb.json"
+            - "--id=demo"
+            - "--debug-delay=2"
+            - "run"
+            - "ctdbd"
+            - "--setup=smb_ctdb"
+            - "--setup=ctdb_config"
+            - "--setup=ctdb_etc"
+            - "--setup=ctdb_nodes"
           env:
-          - name: SAMBACC_CTDB
-            value: "ctdb-is-experimental"
+            - name: SAMBACC_CTDB
+              value: "ctdb-is-experimental"
           volumeMounts:
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
-          - mountPath: "/var/lib/ctdb/persistent"
-            name: ctdb-persistent
-          - mountPath: "/var/lib/ctdb/volatile"
-            name: ctdb-volatile
-          - mountPath: "/etc/ctdb"
-            name: ctdb-config
-          - mountPath: "/var/run/ctdb"
-            name: ctdb-sockets-dir
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
+            - mountPath: "/var/lib/ctdb/persistent"
+              name: ctdb-persistent
+            - mountPath: "/var/lib/ctdb/volatile"
+              name: ctdb-volatile
+            - mountPath: "/etc/ctdb"
+              name: ctdb-config
+            - mountPath: "/var/run/ctdb"
+              name: ctdb-sockets-dir
         - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: ctdb-manage-nodes
           args:
-          - "--config=/usr/local/share/sambacc/examples/ctdb.json"
-          - "--id=demo"
-          - "ctdb-manage-nodes"
-          - "--hostname=$(HOSTNAME)"
-          - "--take-node-number-from-hostname=after-last-dash"
+            - "--config=/usr/local/share/sambacc/examples/ctdb.json"
+            - "--id=demo"
+            - "ctdb-manage-nodes"
+            - "--hostname=$(HOSTNAME)"
+            - "--take-node-number-from-hostname=after-last-dash"
           env:
-          - name: SAMBACC_CTDB
-            value: "ctdb-is-experimental"
-          - name: HOSTNAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
+            - name: SAMBACC_CTDB
+              value: "ctdb-is-experimental"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           volumeMounts:
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
-          - mountPath: "/etc/ctdb"
-            name: ctdb-config
-          - mountPath: "/var/run/ctdb"
-            name: ctdb-sockets-dir
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
+            - mountPath: "/etc/ctdb"
+              name: ctdb-config
+            - mountPath: "/var/run/ctdb"
+              name: ctdb-sockets-dir
         - image: quay.io/samba.org/samba-server:latest
           imagePullPolicy: Always
           name: smb
           args:
-          - "--config=/usr/local/share/sambacc/examples/ctdb.json"
-          - "--id=demo"
-          - "--debug-delay=12"
-          - "run"
-          - "smbd"
-          - "--setup=users"
-          - "--setup=smb_ctdb"
+            - "--config=/usr/local/share/sambacc/examples/ctdb.json"
+            - "--id=demo"
+            - "--debug-delay=12"
+            - "run"
+            - "smbd"
+            - "--setup=users"
+            - "--setup=smb_ctdb"
           ports:
-          - containerPort: 445
-            protocol: TCP
-            name: "smb"
+            - containerPort: 445
+              protocol: TCP
+              name: "smb"
           securityContext:
             allowPrivilegeEscalation: true
           volumeMounts:
-          - mountPath: "/share"
-            name: samba-share-data
-          - mountPath: "/var/lib/ctdb/shared"
-            name: ctdb-shared
-          - mountPath: "/var/lib/ctdb/persistent"
-            name: ctdb-persistent
-          - mountPath: "/var/lib/ctdb/volatile"
-            name: ctdb-volatile
-          - mountPath: "/etc/ctdb"
-            name: ctdb-config
-          - mountPath: "/var/run/ctdb"
-            name: ctdb-sockets-dir
+            - mountPath: "/share"
+              name: samba-share-data
+            - mountPath: "/var/lib/ctdb/shared"
+              name: ctdb-shared
+            - mountPath: "/var/lib/ctdb/persistent"
+              name: ctdb-persistent
+            - mountPath: "/var/lib/ctdb/volatile"
+              name: ctdb-volatile
+            - mountPath: "/etc/ctdb"
+              name: ctdb-config
+            - mountPath: "/var/run/ctdb"
+              name: ctdb-sockets-dir
       volumes:
-      # /etc/ctdb
-      - emptyDir: {}
-        name: ctdb-config
-      # /var/lib/ctdb/persistent
-      - emptyDir: {}
-        name: ctdb-persistent
-      # /var/lib/ctdb/volatile
-      - emptyDir: {}
-        name: ctdb-volatile
-      # /var/lib/ctdb/shared
-      - persistentVolumeClaim:
-          claimName: ctdb-shared
-        name: ctdb-shared
-      # /var/run/ctdb
-      - emptyDir:
-          medium: Memory
-        name: ctdb-sockets-dir
-      # /var/lib/samba
-      - emptyDir: {}
-        name: samba-state-dir
-      # /share
-      - persistentVolumeClaim:
-          claimName: samba-share-data
-        name: samba-share-data
+        # /etc/ctdb
+        - emptyDir: {}
+          name: ctdb-config
+        # /var/lib/ctdb/persistent
+        - emptyDir: {}
+          name: ctdb-persistent
+        # /var/lib/ctdb/volatile
+        - emptyDir: {}
+          name: ctdb-volatile
+        # /var/lib/ctdb/shared
+        - persistentVolumeClaim:
+            claimName: ctdb-shared
+          name: ctdb-shared
+        # /var/run/ctdb
+        - emptyDir:
+            medium: Memory
+          name: ctdb-sockets-dir
+        # /var/lib/samba
+        - emptyDir: {}
+          name: samba-state-dir
+        # /share
+        - persistentVolumeClaim:
+            claimName: samba-share-data
+          name: samba-share-data

--- a/examples/kubernetes/sambadeployment.converged.yml
+++ b/examples/kubernetes/sambadeployment.converged.yml
@@ -16,17 +16,17 @@ spec:
         app: samba
     spec:
       volumes:
-      - name: myvol
-        persistentVolumeClaim:
-          claimName: mypvc
+        - name: myvol
+          persistentVolumeClaim:
+            claimName: mypvc
       containers:
-      - name: samba
-        image: quay.io/samba.org/samba-server:latest
-        ports:
-        - containerPort: 445
-        volumeMounts:
-        - mountPath: "/share"
-          name: myvol
+        - name: samba
+          image: quay.io/samba.org/samba-server:latest
+          ports:
+            - containerPort: 445
+          volumeMounts:
+            - mountPath: "/share"
+              name: myvol
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/examples/kubernetes/sambadeployment.yml
+++ b/examples/kubernetes/sambadeployment.yml
@@ -15,14 +15,14 @@ spec:
         app: samba
     spec:
       volumes:
-      - name: myvol
-        persistentVolumeClaim:
-          claimName: mypvc
+        - name: myvol
+          persistentVolumeClaim:
+            claimName: mypvc
       containers:
-      - name: samba
-        image: quay.io/samba.org/samba-server:latest
-        ports:
-        - containerPort: 445
-        volumeMounts:
-        - mountPath: "/share"
-          name: myvol
+        - name: samba
+          image: quay.io/samba.org/samba-server:latest
+          ports:
+            - containerPort: 445
+          volumeMounts:
+            - mountPath: "/share"
+              name: myvol

--- a/examples/kubernetes/sambadmpod.yml
+++ b/examples/kubernetes/sambadmpod.yml
@@ -101,125 +101,125 @@ spec:
     - image: quay.io/samba.org/samba-server:latest
       name: smb
       command:
-      - "samba-container"
-      - "--debug-delay=1"
-      - "run"
-      - "smbd"
+        - "samba-container"
+        - "--debug-delay=1"
+        - "run"
+        - "smbd"
       env:
-      - name: SAMBACC_CONFIG
-        value: /etc/samba-container/config.json
-      - name: SAMBA_CONTAINER_ID
-        value: sambadm1
-      - name: SAMBACC_VERSION
-        value: "0.1"
-      - name: HOSTNAME
-        value: sambadm1
+        - name: SAMBACC_CONFIG
+          value: /etc/samba-container/config.json
+        - name: SAMBA_CONTAINER_ID
+          value: sambadm1
+        - name: SAMBACC_VERSION
+          value: "0.1"
+        - name: HOSTNAME
+          value: sambadm1
       ports:
-      - containerPort: 445
-        hostPort: 455
-        protocol: TCP
-        name: "smb"
+        - containerPort: 445
+          hostPort: 455
+          protocol: TCP
+          name: "smb"
       securityContext:
         allowPrivilegeEscalation: true
       volumeMounts:
-      - mountPath: "/share"
-        name: samba-sharedir
-      - mountPath: "/etc/samba-container"
-        name: samba-container-config
-      - mountPath: "/var/lib/samba"
-        name: samba-state-dir
-      - mountPath: "/run/samba/winbindd"
-        name: samba-sockets-dir
+        - mountPath: "/share"
+          name: samba-sharedir
+        - mountPath: "/etc/samba-container"
+          name: samba-container-config
+        - mountPath: "/var/lib/samba"
+          name: samba-state-dir
+        - mountPath: "/run/samba/winbindd"
+          name: samba-sockets-dir
     - image: quay.io/samba.org/samba-server:latest
       name: winbind
       command:
-      - "samba-container"
-      - "run"
-      - "winbindd"
+        - "samba-container"
+        - "run"
+        - "winbindd"
       env:
-      - name: SAMBACC_VERSION
-        value: "0.1"
-      - name: SAMBACC_CONFIG
-        value: /etc/samba-container/config.json
-      - name: SAMBA_CONTAINER_ID
-        value: sambadm1
-      - name: HOSTNAME
-        value: sambadm1
+        - name: SAMBACC_VERSION
+          value: "0.1"
+        - name: SAMBACC_CONFIG
+          value: /etc/samba-container/config.json
+        - name: SAMBA_CONTAINER_ID
+          value: sambadm1
+        - name: HOSTNAME
+          value: sambadm1
       securityContext:
         allowPrivilegeEscalation: true
       volumeMounts:
-      - mountPath: "/etc/samba-container"
-        name: samba-container-config
-      - mountPath: "/var/lib/samba"
-        name: samba-state-dir
-      - mountPath: "/run/samba/winbindd"
-        name: samba-sockets-dir
+        - mountPath: "/etc/samba-container"
+          name: samba-container-config
+        - mountPath: "/var/lib/samba"
+          name: samba-state-dir
+        - mountPath: "/run/samba/winbindd"
+          name: samba-sockets-dir
   initContainers:
     - image: quay.io/samba.org/samba-server:latest
       name: init
       args:
-      - "init"
+        - "init"
       env:
-      - name: SAMBACC_VERSION
-        value: "0.1"
-      - name: SAMBACC_CONFIG
-        value: /etc/samba-container/config.json
-      - name: SAMBA_CONTAINER_ID
-        value: sambadm1
-      - name: HOSTNAME
-        value: sambadm1
+        - name: SAMBACC_VERSION
+          value: "0.1"
+        - name: SAMBACC_CONFIG
+          value: /etc/samba-container/config.json
+        - name: SAMBA_CONTAINER_ID
+          value: sambadm1
+        - name: HOSTNAME
+          value: sambadm1
       securityContext:
         allowPrivilegeEscalation: true
       volumeMounts:
-      - mountPath: "/etc/samba-container"
-        name: samba-container-config
-      - mountPath: "/var/lib/samba"
-        name: samba-state-dir
+        - mountPath: "/etc/samba-container"
+          name: samba-container-config
+        - mountPath: "/var/lib/samba"
+          name: samba-state-dir
     - image: quay.io/samba.org/samba-server:latest
       name: must-join
       args:
-      - "must-join"
-      - "--files"
-      - "--join-file=/etc/join-data/join.json"
+        - "must-join"
+        - "--files"
+        - "--join-file=/etc/join-data/join.json"
       env:
-      - name: SAMBACC_VERSION
-        value: "0.1"
-      - name: SAMBACC_CONFIG
-        value: /etc/samba-container/config.json
-      - name: SAMBA_CONTAINER_ID
-        value: sambadm1
-      - name: HOSTNAME
-        value: sambadm1
+        - name: SAMBACC_VERSION
+          value: "0.1"
+        - name: SAMBACC_CONFIG
+          value: /etc/samba-container/config.json
+        - name: SAMBA_CONTAINER_ID
+          value: sambadm1
+        - name: HOSTNAME
+          value: sambadm1
       securityContext:
         allowPrivilegeEscalation: true
       volumeMounts:
-      - mountPath: "/etc/samba-container"
-        name: samba-container-config
-      - mountPath: "/var/lib/samba"
-        name: samba-state-dir
-      - mountPath: "/etc/join-data"
-        name: samba-join-data
-        readOnly: true
+        - mountPath: "/etc/samba-container"
+          name: samba-container-config
+        - mountPath: "/var/lib/samba"
+          name: samba-state-dir
+        - mountPath: "/etc/join-data"
+          name: samba-join-data
+          readOnly: true
   volumes:
-  - configMap:
+    - configMap:
+        name: samba-container-config
       name: samba-container-config
-    name: samba-container-config
-  - secret:
-      secretName: ad-join-secret
-      items:
-      - key: join.json
-        path: join.json
-    name: samba-join-data
-  - emptyDir:
-      medium: Memory
-    name: samba-sockets-dir
-  - emptyDir: {}
-    name: samba-state-dir
-# Comment out the section below to skip using a PVC for the share
-  - persistentVolumeClaim:
-      claimName: mypvc
-    name: samba-sharedir
-# Uncomment the section below to use an empty dir for the share
-#  - emptyDir:
-#      medium: Memory
-#    name: samba-sharedir
+    - secret:
+        secretName: ad-join-secret
+        items:
+          - key: join.json
+            path: join.json
+      name: samba-join-data
+    - emptyDir:
+        medium: Memory
+      name: samba-sockets-dir
+    - emptyDir: {}
+      name: samba-state-dir
+    # Comment out the section below to skip using a PVC for the share
+    - persistentVolumeClaim:
+        claimName: mypvc
+      name: samba-sharedir
+      # Uncomment the section below to use an empty dir for the share
+      #  - emptyDir:
+      #      medium: Memory
+      #    name: samba-sharedir

--- a/examples/kubernetes/sambapod.yml
+++ b/examples/kubernetes/sambapod.yml
@@ -16,4 +16,3 @@ spec:
       volumeMounts:
         - mountPath: "/share"
           name: myvol
-

--- a/tests/files/samba-ad-server-deployment.yml
+++ b/tests/files/samba-ad-server-deployment.yml
@@ -15,47 +15,47 @@ spec:
         app: samba-ad
     spec:
       containers:
-      - name: samba
-        # Pointing to locally built image,
-        # change here to use a registry.
-        image: samba-ad-server:$IMG_TAG
-        # Need imagePullPolicy Never for working with local images.
-        # Otherwise we get "ErrImagePull".
-        imagePullPolicy: Never
-        securityContext:
-          capabilities:
-            add: ["SYS_ADMIN"]
-        ports:
-        # https://wiki.samba.org/index.php/Samba_AD_DC_Port_Usage
-        - containerPort: 53
-          name: dns
-        - containerPort: 135
-          name: epm
-          protocol: TCP
-        - containerPort: 137
-          name: netbios-ns
-          protocol: UDP
-        - containerPort: 138
-          name: netbios-dgram
-          protocol: UDP
-        - containerPort: 139
-          name: netbios-session
-          protocol: TCP
-        - containerPort: 389
-          name: ldap
-        - containerPort: 445
-          name: smb
-          protocol: TCP
-        - containerPort: 464
-          name: kerberos
-        - containerPort: 636
-          name: ldaps
-          protocol: TCP
-        - containerPort: 3268
-          name: gc
-          protocol: TCP
-        - containerPort: 3269
-          name: gc-ssl
-          protocol: TCP
-        # need 49152-65535 for dynamic RPC ports
-        # but currently not possible to specify ranges
+        - name: samba
+          # Pointing to locally built image,
+          # change here to use a registry.
+          image: samba-ad-server:$IMG_TAG
+          # Need imagePullPolicy Never for working with local images.
+          # Otherwise we get "ErrImagePull".
+          imagePullPolicy: Never
+          securityContext:
+            capabilities:
+              add: ["SYS_ADMIN"]
+          ports:
+            # https://wiki.samba.org/index.php/Samba_AD_DC_Port_Usage
+            - containerPort: 53
+              name: dns
+            - containerPort: 135
+              name: epm
+              protocol: TCP
+            - containerPort: 137
+              name: netbios-ns
+              protocol: UDP
+            - containerPort: 138
+              name: netbios-dgram
+              protocol: UDP
+            - containerPort: 139
+              name: netbios-session
+              protocol: TCP
+            - containerPort: 389
+              name: ldap
+            - containerPort: 445
+              name: smb
+              protocol: TCP
+            - containerPort: 464
+              name: kerberos
+            - containerPort: 636
+              name: ldaps
+              protocol: TCP
+            - containerPort: 3268
+              name: gc
+              protocol: TCP
+            - containerPort: 3269
+              name: gc-ssl
+              protocol: TCP
+              # need 49152-65535 for dynamic RPC ports
+              # but currently not possible to specify ranges

--- a/tests/files/samba-domain-member-pod.yml
+++ b/tests/files/samba-domain-member-pod.yml
@@ -80,128 +80,128 @@ spec:
       imagePullPolicy: $IMG_PULL_POLICY
       name: smb
       command:
-      - "samba-container"
-      - "--debug-delay=1"
-      - "run"
-      - "smbd"
+        - "samba-container"
+        - "--debug-delay=1"
+        - "run"
+        - "smbd"
       env:
-      - name: SAMBACC_CONFIG
-        value: /etc/samba-container/config.json
-      - name: SAMBA_CONTAINER_ID
-        value: sambadm1
-      - name: SAMBACC_VERSION
-        value: "0.1"
-      - name: HOSTNAME
-        value: sambadm1
+        - name: SAMBACC_CONFIG
+          value: /etc/samba-container/config.json
+        - name: SAMBA_CONTAINER_ID
+          value: sambadm1
+        - name: SAMBACC_VERSION
+          value: "0.1"
+        - name: HOSTNAME
+          value: sambadm1
       ports:
-      - containerPort: 445
-        hostPort: 455
-        protocol: TCP
-        name: "smb"
+        - containerPort: 445
+          hostPort: 455
+          protocol: TCP
+          name: "smb"
       securityContext:
         allowPrivilegeEscalation: true
       volumeMounts:
-      - mountPath: "/share"
-        name: samba-sharedir
-      - mountPath: "/etc/samba-container"
-        name: samba-container-config
-      - mountPath: "/var/lib/samba"
-        name: samba-state-dir
-      - mountPath: "/run/samba/winbindd"
-        name: samba-sockets-dir
+        - mountPath: "/share"
+          name: samba-sharedir
+        - mountPath: "/etc/samba-container"
+          name: samba-container-config
+        - mountPath: "/var/lib/samba"
+          name: samba-state-dir
+        - mountPath: "/run/samba/winbindd"
+          name: samba-sockets-dir
     - image: $IMG_NAME
       imagePullPolicy: $IMG_PULL_POLICY
       name: winbind
       command:
-      - "samba-container"
-      - "run"
-      - "winbindd"
+        - "samba-container"
+        - "run"
+        - "winbindd"
       env:
-      - name: SAMBACC_VERSION
-        value: "0.1"
-      - name: SAMBACC_CONFIG
-        value: /etc/samba-container/config.json
-      - name: SAMBA_CONTAINER_ID
-        value: sambadm1
-      - name: HOSTNAME
-        value: sambadm1
+        - name: SAMBACC_VERSION
+          value: "0.1"
+        - name: SAMBACC_CONFIG
+          value: /etc/samba-container/config.json
+        - name: SAMBA_CONTAINER_ID
+          value: sambadm1
+        - name: HOSTNAME
+          value: sambadm1
       securityContext:
         allowPrivilegeEscalation: true
       volumeMounts:
-      - mountPath: "/etc/samba-container"
-        name: samba-container-config
-      - mountPath: "/var/lib/samba"
-        name: samba-state-dir
-      - mountPath: "/run/samba/winbindd"
-        name: samba-sockets-dir
+        - mountPath: "/etc/samba-container"
+          name: samba-container-config
+        - mountPath: "/var/lib/samba"
+          name: samba-state-dir
+        - mountPath: "/run/samba/winbindd"
+          name: samba-sockets-dir
   initContainers:
     - image: $IMG_NAME
       imagePullPolicy: $IMG_PULL_POLICY
       name: init
       args:
-      - "init"
+        - "init"
       env:
-      - name: SAMBACC_VERSION
-        value: "0.1"
-      - name: SAMBACC_CONFIG
-        value: /etc/samba-container/config.json
-      - name: SAMBA_CONTAINER_ID
-        value: sambadm1
-      - name: HOSTNAME
-        value: sambadm1
+        - name: SAMBACC_VERSION
+          value: "0.1"
+        - name: SAMBACC_CONFIG
+          value: /etc/samba-container/config.json
+        - name: SAMBA_CONTAINER_ID
+          value: sambadm1
+        - name: HOSTNAME
+          value: sambadm1
       securityContext:
         allowPrivilegeEscalation: true
       volumeMounts:
-      - mountPath: "/etc/samba-container"
-        name: samba-container-config
-      - mountPath: "/var/lib/samba"
-        name: samba-state-dir
+        - mountPath: "/etc/samba-container"
+          name: samba-container-config
+        - mountPath: "/var/lib/samba"
+          name: samba-state-dir
     - image: $IMG_NAME
       imagePullPolicy: $IMG_PULL_POLICY
       name: must-join
       args:
-      - "must-join"
-      - "--files"
-      - "--join-file=/etc/join-data/join.json"
+        - "must-join"
+        - "--files"
+        - "--join-file=/etc/join-data/join.json"
       env:
-      - name: SAMBACC_VERSION
-        value: "0.1"
-      - name: SAMBACC_CONFIG
-        value: /etc/samba-container/config.json
-      - name: SAMBA_CONTAINER_ID
-        value: sambadm1
-      - name: HOSTNAME
-        value: sambadm1
+        - name: SAMBACC_VERSION
+          value: "0.1"
+        - name: SAMBACC_CONFIG
+          value: /etc/samba-container/config.json
+        - name: SAMBA_CONTAINER_ID
+          value: sambadm1
+        - name: HOSTNAME
+          value: sambadm1
       securityContext:
         allowPrivilegeEscalation: true
       volumeMounts:
-      - mountPath: "/etc/samba-container"
-        name: samba-container-config
-      - mountPath: "/var/lib/samba"
-        name: samba-state-dir
-      - mountPath: "/etc/join-data"
-        name: samba-join-data
-        readOnly: true
+        - mountPath: "/etc/samba-container"
+          name: samba-container-config
+        - mountPath: "/var/lib/samba"
+          name: samba-state-dir
+        - mountPath: "/etc/join-data"
+          name: samba-join-data
+          readOnly: true
   volumes:
-  - configMap:
+    - configMap:
+        name: samba-container-config
       name: samba-container-config
-    name: samba-container-config
-  - secret:
-      secretName: ad-join-secret
-      items:
-      - key: join.json
-        path: join.json
-    name: samba-join-data
-  - emptyDir:
-      medium: Memory
-    name: samba-sockets-dir
-  - emptyDir: {}
-    name: samba-state-dir
-# Comment out the section below to skip using a PVC for the share
-#  - persistentVolumeClaim:
-#      claimName: mypvc
-#    name: samba-sharedir
-# Uncomment the section below to use an empty dir for the share
-  - emptyDir:
-      medium: Memory
-    name: samba-sharedir
+    - secret:
+        secretName: ad-join-secret
+        items:
+          - key: join.json
+            path: join.json
+      name: samba-join-data
+    - emptyDir:
+        medium: Memory
+      name: samba-sockets-dir
+    - emptyDir: {}
+      name: samba-state-dir
+    # Comment out the section below to skip using a PVC for the share
+    #  - persistentVolumeClaim:
+    #      claimName: mypvc
+    #    name: samba-sharedir
+    # Uncomment the section below to use an empty dir for the share
+    - emptyDir:
+        medium: Memory
+      name: samba-sharedir


### PR DESCRIPTION
The title says it all. Tedious but straightforward.  Gets rid of the noise when running `make check-yaml` so you can more easily see if you've introduced an error or warning.
I disagree with yaml lint on certain trailing comments, but I just went with the flow for now.