### PR TITLE
gitlint: allow commit messages to contain long footnotes

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -30,6 +30,9 @@ ignore-merge-commits=true
 # Enable debug mode (prints more output). Disabled by default.
 # debug=true
 
+# Enable search regex and remove warning message.
+regex-style-search=true
+
 # Enable community contributed rules
 # See http://jorisroovers.github.io/gitlint/contrib_rules for details
 # contrib=contrib-body-requires-signed-off-by
@@ -106,10 +109,15 @@ regex=^.*
 # Use 'all' to ignore all rules
 # ignore=T1,body-min-length
 
-# [ignore-body-lines]
+[ignore-body-lines]
 # Ignore certain lines in a commit body that match a regex.
 # E.g. Ignore all lines that start with 'Co-Authored-By'
 # regex=^Co-Authored-By
+
+# ignore lines that are "footnotes", that start like `[1]: ` or `[2]: ` and so on
+# this will make it easy to put long urls in commit messages without
+# triggering gitlint body rules
+regex=^\[[0-9]+\]:? +
 
 # This is a contrib rule - a community contributed rule. These are disabled by default.
 # You need to explicitly enable them one-by-one by adding them to the "contrib" option


### PR DESCRIPTION
Configure gitlint to ignore lines that start like `[1]: ` or `[2] ` such that we can have  long text like URLs in the commits without triggering other gitlint body     rules.

PR contains two test commits to demonstrate the change that must be removed prior to merging.