### PR TITLE
hack: fix --push option to build-image

### DIFF
--- a/hack/build-image
+++ b/hack/build-image
@@ -394,7 +394,7 @@ def push(cli, target):
             build(cli, target)
 
     push_name = target.image_name()
-    for tag in target.additional_tags:
+    for tag, _ in target.additional_tags:
         if tag in ("latest", "nightly"):
             push_name = target.image_name(tag=tag)
             break


### PR DESCRIPTION
Fixes: #151 

Late in the development of `build-image` I made additional_tags a list of tuples rather than a list of strings in order to make filtering simpler but `push` function was never updated to match. This quick fix gets `--push` mode working again.