### PR TITLE
xxx: do not merge

### DIFF
--- a/images/ad-server/Containerfile.opensuse
+++ b/images/ad-server/Containerfile.opensuse
@@ -32,6 +32,7 @@ RUN zypper --non-interactive install --no-recommends \
   samba-client \
   samba-winbind \
   python3-dnspython \
+  python3-Markdown \
   krb5-server \
   sambacc && \
   zypper clean;


### PR DESCRIPTION
Just to check if there are any problems beyond the python3-Markdown dependency. Hopefully we will get a fixed version of opensuse's samba package instead.