### PR TITLE
hack: some tweaks for the build-image script

### DIFF
--- a/hack/build-image
+++ b/hack/build-image
@@ -48,6 +48,12 @@ import sys
 
 logger = logging.getLogger("build-image")
 
+# Set FORCE_ARCH_FLAG if you want to test passing the --arch flag to podman all
+# the time. This was the previous behavior but we found it to have some issues.
+# When this is false the --arch flag is passed to podman ONLY when the target
+# arch != the host system arch.
+FORCE_ARCH_FLAG = False
+
 # IMAGE_KINDS - map aliases/names to canonical names for the kinds
 # of images we can build
 IMG_SERVER = "samba-server"
@@ -196,7 +202,13 @@ def container_build(cli, target):
     if "docker" in args[0]:
         if target.arch != host_arch():
             raise RuntimeError("Docker does not support --arch")
-    else:
+    elif target.arch != host_arch() or FORCE_ARCH_FLAG:
+        # We've noticed a few small quirks when using podman with the --arch
+        # option. The main issue is that building the client image works
+        # but then the toolbox image fails because it somehow doesn't see
+        # the image we just built as usable. This doesn't happen when
+        # --arch is not provided. So if the target arch and the host_arch
+        # are the same, skip passing the extra argument.
         args.append(f"--arch={target.arch}")
     if cli.extra_build_arg:
         args.extend(cli.extra_build_arg)

--- a/hack/build-image
+++ b/hack/build-image
@@ -363,7 +363,7 @@ def generate_images(cli):
     return list(images.values())
 
 
-def add_special_tags(img):
+def add_special_tags(img, distro_qualified=True):
     """Certain images have special tags. Given an image, add general (non-FQIN)
     tags to that image.
     """
@@ -376,6 +376,8 @@ def add_special_tags(img):
             img.additional_tags.append((LATEST, QUAL_NONE))
         if img.arch == host_arch() and img.pkg_source == NIGHTLY:
             img.additional_tags.append((NIGHTLY, QUAL_NONE))
+    if not distro_qualified:
+        return  # skip creating "distro qualified" tags
     if img.arch == host_arch() and img.pkg_source == "default":
         img.additional_tags.append((f"{img.distro}-{LATEST}", QUAL_DISTRO))
     if img.arch == host_arch() and img.pkg_source == "nightly":
@@ -550,6 +552,15 @@ def main():
             " without the repo base"
         ),
     )
+    parser.add_argument(
+        "--distro-qualified",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Specify if image tags like fedora-nightly or centos-latest"
+            " will be created."
+        ),
+    )
     behaviors = parser.add_mutually_exclusive_group()
     behaviors.add_argument(
         "--push",
@@ -590,7 +601,7 @@ def main():
     try:
         imgs = generate_images(cli)
         for img in imgs:
-            add_special_tags(img)
+            add_special_tags(img, cli.distro_qualified)
             logger.info("Image %s, extra tags: %s", img, img.additional_tags)
             _action(cli, img)
     except subprocess.CalledProcessError as err:


### PR DESCRIPTION
Avoid passing the --arch option to podman for building the host architecture.

Add an option to skip adding tags meant primarily for backwards compatibility with the earlier makefile based builds.