### PR TITLE
Add ceph support for centos based images

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -47,6 +47,10 @@ jobs:
           # there are no nightly packages for opensuse
           - package_source: nightly
             os: opensuse
+        include:
+          - package_source: devbuilds
+            os: centos
+            arch: amd64
     runs-on: ubuntu-latest
     env:
       BUILDAH_FORMAT: oci
@@ -150,6 +154,10 @@ jobs:
           # there are no nightly packages for opensuse
           - package_source: nightly
             os: opensuse
+        include:
+          - package_source: devbuilds
+            os: centos
+            arch: amd64
     needs: build-server
     runs-on: ubuntu-latest
     env:

--- a/hack/build-image
+++ b/hack/build-image
@@ -98,7 +98,14 @@ DISTROS = [
 # PACKAGE_SOURCES - list of known package sources
 DEFAULT = "default"
 NIGHTLY = "nightly"
-PACKAGE_SOURCES = [DEFAULT, NIGHTLY]
+DEVBUILDS = "devbuilds"
+PACKAGE_SOURCES = [DEFAULT, NIGHTLY, DEVBUILDS]
+
+PACKAGES_FROM = {
+    DEFAULT: '',
+    NIGHTLY: 'samba-nightly',
+    DEVBUILDS: 'devbuilds',
+}
 
 # SOURCE_DIRS - image source paths
 # (paths are relative to common image source dir)
@@ -196,8 +203,9 @@ def container_engine(cli):
 def container_build(cli, target):
     """Construct and execute a command to build the target container image."""
     args = [container_engine(cli), "build"]
-    if target.pkg_source == NIGHTLY:
-        args.append("--build-arg=INSTALL_PACKAGES_FROM=samba-nightly")
+    pkgs_from = PACKAGES_FROM[target.pkg_source]
+    if pkgs_from:
+        args.append(f"--build-arg=INSTALL_PACKAGES_FROM={pkgs_from}")
     # docker doesn't currently support alt. architectures
     if "docker" in args[0]:
         if target.arch != host_arch():

--- a/images/ad-server/install-packages.sh
+++ b/images/ad-server/install-packages.sh
@@ -19,8 +19,6 @@ OS_BASE="$(. /etc/os-release && echo "${ID}")"
 
 case "${install_packages_from}" in
     samba-nightly)
-        # unset version suffix for nightly builds
-        samba_version_suffix=""
         get_custom_repo "https://artifacts.ci.centos.org/samba/pkgs/master/${OS_BASE}/samba-nightly-master.repo"
     ;;
     custom-repo)

--- a/images/server/Containerfile.centos
+++ b/images/server/Containerfile.centos
@@ -4,6 +4,7 @@ ARG SAMBA_VERSION_SUFFIX=""
 ARG SAMBACC_VERSION_SUFFIX=""
 ARG SAMBA_SPECIFICS=daemon_cli_debug_output,ctdb_leader_admin_command
 ARG INSTALL_CUSTOM_REPO=
+ARG PACKAGE_SELECTION=
 
 MAINTAINER John Mulligan <jmulligan@redhat.com>
 
@@ -18,7 +19,8 @@ COPY install-packages.sh /usr/local/bin/install-packages.sh
 RUN /usr/local/bin/install-packages.sh \
     "${INSTALL_PACKAGES_FROM}" \
     "${SAMBA_VERSION_SUFFIX}" \
-    "${INSTALL_CUSTOM_REPO}"
+    "${INSTALL_CUSTOM_REPO}" \
+    "${PACKAGE_SELECTION}"
 
 # If you want to install a custom version of sambacc into this image mount
 # a directory containing a sambacc RPM, or a sambacc wheel, or a .repo

--- a/images/server/Containerfile.fedora
+++ b/images/server/Containerfile.fedora
@@ -4,6 +4,7 @@ ARG SAMBA_VERSION_SUFFIX=""
 ARG SAMBACC_VERSION_SUFFIX=""
 ARG SAMBA_SPECIFICS=daemon_cli_debug_output,ctdb_leader_admin_command
 ARG INSTALL_CUSTOM_REPO=
+ARG PACKAGE_SELECTION=
 
 MAINTAINER John Mulligan <jmulligan@redhat.com>
 
@@ -17,7 +18,8 @@ COPY install-packages.sh /usr/local/bin/install-packages.sh
 RUN /usr/local/bin/install-packages.sh \
     "${INSTALL_PACKAGES_FROM}" \
     "${SAMBA_VERSION_SUFFIX}" \
-    "${INSTALL_CUSTOM_REPO}"
+    "${INSTALL_CUSTOM_REPO}" \
+    "${PACKAGE_SELECTION}"
 
 # If you want to install a custom version of sambacc into this image mount
 # a directory containing a sambacc RPM, or a sambacc wheel, or a .repo

--- a/images/server/install-packages.sh
+++ b/images/server/install-packages.sh
@@ -51,6 +51,10 @@ OS_BASE="$(. /etc/os-release && echo "${ID}")"
 case "${install_packages_from}" in
     samba-nightly)
         get_custom_repo "https://artifacts.ci.centos.org/samba/pkgs/master/${OS_BASE}/samba-nightly-master.repo"
+        if [[ "${OS_BASE}" = centos ]]; then
+            dnf install --setopt=install_weak_deps=False -y \
+                epel-release centos-release-ceph-reef
+        fi
         package_selection=${package_selection:-nightly}
     ;;
     devbuilds)
@@ -93,7 +97,7 @@ case "${package_selection}-${OS_BASE}" in
     *-fedora|allvfs-*)
         samba_packages+=(samba-vfs-cephfs samba-vfs-glusterfs)
     ;;
-    devbuilds-centos|forcedevbuilds-*)
+    nightly-centos|devbuilds-centos|forcedevbuilds-*)
         dnf_cmd+=(--enablerepo=epel)
         samba_packages+=(samba-vfs-cephfs)
         # these packages should be installed as deps. of sambacc extras

--- a/images/server/install-packages.sh
+++ b/images/server/install-packages.sh
@@ -2,12 +2,42 @@
 
 set -ex
 
+
+need_curl() {
+    if command -v curl >/dev/null ; then
+        return 0
+    fi
+    dnf install --setopt=install_weak_deps=False -y /usr/bin/curl
+}
+
 get_custom_repo() {
     url="$1"
     fname="$(basename "$url")"
     dest="/etc/yum.repos.d/${fname}"
-    dnf install --setopt=install_weak_deps=False -y /usr/bin/curl
+    need_curl
     curl -L "$url" -o "$dest"
+}
+
+generate_repo_from_shaman() {
+    url="$1"
+    dest="/etc/yum.repos.d/$2"
+    need_curl
+    tmpfile=/tmp/shaman.json
+    curl -L "$url" -o "${tmpfile}" && python3 <<EOF
+json_file = "${tmpfile}"
+dest = "${dest}"
+import json
+r = json.load(open(json_file))
+url = r[0]["url"]
+ref = r[0]["ref"]
+with open(dest, "w") as out:
+    print(f"[ceph-{ref}]", file=out)
+    print(f"name=Ceph Development Build ({ref})", file=out)
+    print(f"baseurl={url}/x86_64", file=out)
+    print("enabled=1", file=out)
+    print("gpgcheck=0", file=out)
+EOF
+    rm -rf "${tmpfile}"
 }
 
 install_packages_from="$1"
@@ -23,10 +53,23 @@ case "${install_packages_from}" in
         get_custom_repo "https://artifacts.ci.centos.org/samba/pkgs/master/${OS_BASE}/samba-nightly-master.repo"
         package_selection=${package_selection:-nightly}
     ;;
+    devbuilds)
+        # devbuilds - samba nightly dev builds and ceph dev builds
+        get_custom_repo "https://artifacts.ci.centos.org/samba/pkgs/master/${OS_BASE}/samba-nightly-master.repo"
+        generate_repo_from_shaman "https://shaman.ceph.com/api/search/?project=ceph&distros=${OS_BASE}/9/x86_64&flavor=default&ref=main&sha1=latest" ceph-main.repo
+        dnf install --setopt=install_weak_deps=False -y epel-release
+        package_selection=${package_selection:-devbuilds}
+    ;;
     custom-repo)
         get_custom_repo "${install_custom_repo}"
     ;;
 esac
+
+
+dnf_cmd=(dnf)
+if [[ "${OS_BASE}" = centos ]]; then
+    dnf_cmd+=(--enablerepo=crb --enablerepo=resilientstorage)
+fi
 
 
 # Assorted packages that must be installed in the container image to
@@ -50,6 +93,14 @@ case "${package_selection}-${OS_BASE}" in
     *-fedora|allvfs-*)
         samba_packages+=(samba-vfs-cephfs samba-vfs-glusterfs)
     ;;
+    devbuilds-centos|forcedevbuilds-*)
+        dnf_cmd+=(--enablerepo=epel)
+        samba_packages+=(samba-vfs-cephfs)
+        # these packages should be installed as deps. of sambacc extras
+        # however, the sambacc builds do not enable the extras on centos atm.
+        # Once this is fixed this line ought to be removed.
+        support_packages+=(python3-pyyaml python3-tomli python3-rados)
+    ;;
 esac
 
 # Assign version suffix to samba packages
@@ -58,10 +109,6 @@ for p in "${samba_packages[@]}"; do
     samba_versioned_packages+=("${p}${samba_version_suffix}")
 done
 
-dnf_cmd=(dnf)
-if [[ "${OS_BASE}" = centos ]]; then
-    dnf_cmd+=(--enablerepo=crb --enablerepo=resilientstorage)
-fi
 
 "${dnf_cmd[@]}" \
     install --setopt=install_weak_deps=False -y \

--- a/images/server/install-packages.sh
+++ b/images/server/install-packages.sh
@@ -19,8 +19,6 @@ OS_BASE="$(. /etc/os-release && echo "${ID}")"
 
 case "${install_packages_from}" in
     samba-nightly)
-        # unset version suffix for nightly builds
-        samba_version_suffix=""
         get_custom_repo "https://artifacts.ci.centos.org/samba/pkgs/master/${OS_BASE}/samba-nightly-master.repo"
     ;;
     custom-repo)


### PR DESCRIPTION
Ensure ceph support exists in the centos based images. Ceph support (for the samba vfs module and sambacc) was already present in the Fedora based images due to (a) fedora packages cephs in the main repos (b) the samba and sambacc RPMs having correct dependencies, as long as the proper samba  vfs modules are selected. These changes will enable ceph libraries to be installed on the samba server image when based on centos and works around some issues in the sambacc dependencies as well.

Add a new package source called "devbuilds" that is valid for centos based images. It enables both the samba nightly builds repo (like the existing "nightly" package source) as well as dev builds from ceph's main branch.

In order to do this cleanly the script and images are refactored slightly to re-organize how packages are selected for install.

Finally, enable ceph builds from the reef branch on centos nightly - note that there's a bug in the current version of reef that prevents the client from talking to newer mds servers but that will eventually get resolved (Hopefully).