### PR TITLE
workflows: restructure the push job

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -226,7 +226,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: log in to quay.io
-        run: docker login -u "${{ secrets.QUAY_USER }}" -p "${{ secrets.QUAY_PASS }}" quay.io
+        run: ${CONTAINER_CMD} login -u "${{ secrets.QUAY_USER }}" -p "${{ secrets.QUAY_PASS }}" quay.io
       - name: push server image
         run: make push-server
       - name: push ad-server image

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -247,6 +247,16 @@ jobs:
         with:
           image: "samba-server:nightly-fedora-amd64"
           container_engine: ${{ env.CONTAINER_CMD }}
+      - name: Fetch server nightly-centos-amd64
+        uses: ishworkh/container-image-artifact-download@v1.0.0
+        with:
+          image: "samba-server:nightly-centos-amd64"
+          container_engine: ${{ env.CONTAINER_CMD }}
+      - name: Fetch server devbuilds-centos-amd64
+        uses: ishworkh/container-image-artifact-download@v1.0.0
+        with:
+          image: "samba-server:devbuilds-centos-amd64"
+          container_engine: ${{ env.CONTAINER_CMD }}
       # (ad server images)
       - name: Fetch ad-server default-fedora-amd64
         uses: ishworkh/container-image-artifact-download@v1.0.0
@@ -280,6 +290,8 @@ jobs:
           --no-distro-qualified
           -i samba-server:default-fedora-amd64
           -i samba-server:nightly-fedora-amd64
+          -i samba-server:nightly-centos-amd64
+          -i samba-server:devbuilds-centos-amd64
           -i samba-ad-server:default-fedora-amd64
           -i samba-ad-server:nightly-fedora-amd64
           -i samba-client:default-fedora-amd64
@@ -294,6 +306,8 @@ jobs:
           --push-selected-tags=mixed
           -i ${REPO_BASE}/samba-server:default-fedora-amd64
           -i ${REPO_BASE}/samba-server:nightly-fedora-amd64
+          -i ${REPO_BASE}/samba-server:nightly-centos-amd64
+          -i ${REPO_BASE}/samba-server:devbuilds-centos-amd64
           -i ${REPO_BASE}/samba-ad-server:default-fedora-amd64
           -i ${REPO_BASE}/samba-ad-server:nightly-fedora-amd64
           -i ${REPO_BASE}/samba-client:default-fedora-amd64

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -107,8 +107,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: build the client image
         run: make KIND=client OS_NAME=${{ matrix.os }} BUILD_ARCH=${{ matrix.arch }} build-image
-      # Here we upload samba-client image to artifacts locally for consumption
-      # during  the samba-toolbox build process.
+      # The client image is used as a base for the samba-toolbox build process.
       - name: Upload the client image
         uses: ishworkh/container-image-artifact-upload@v1.0.0
         with:
@@ -143,6 +142,13 @@ jobs:
         run: ${{ env.CONTAINER_CMD }} tag samba-client:${{ env.IMG_TAG }} quay.io/samba.org/samba-client:latest
       - name: Build the toolbox image
         run: make KIND=toolbox OS_NAME=${{ matrix.os }}  BUILD_ARCH=${{ matrix.arch }} build-image
+      # Upload the toolbox image for reference and/or image push
+      - name: Upload the toolbox image
+        uses: ishworkh/container-image-artifact-upload@v1.0.0
+        with:
+          image: "samba-toolbox:${{ env.IMG_TAG }}"
+          container_engine: ${{ env.CONTAINER_CMD }}
+          retention_days: 1
 
   test-server:
     strategy:

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -228,20 +228,73 @@ jobs:
       - test-server
       - test-ad-server-kubernetes
     runs-on: ubuntu-latest
+    env:
+      REPO_BASE: quay.io/samba.org
     if: (github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'samba-in-kubernetes/samba-container'
     steps:
       - uses: actions/checkout@v3
       - name: log in to quay.io
         run: ${CONTAINER_CMD} login -u "${{ secrets.QUAY_USER }}" -p "${{ secrets.QUAY_PASS }}" quay.io
-      - name: push server image
-        run: make push-server
-      - name: push ad-server image
-        run: make push-ad-server
-      - name: push client image
-        run: make push-client
-      - name: push toolbox image
-        run: make push-toolbox
-      - name: push nightly server image
-        run: make push-nightly-server
-      - name: push nightly ad server image
-        run: make push-nightly-ad-server
+      # pull in already built images we plan on pushing
+      # (server images)
+      - name: Fetch server default-fedora-amd64
+        uses: ishworkh/container-image-artifact-download@v1.0.0
+        with:
+          image: "samba-server:default-fedora-amd64"
+          container_engine: ${{ env.CONTAINER_CMD }}
+      - name: Fetch server nightly-fedora-amd64
+        uses: ishworkh/container-image-artifact-download@v1.0.0
+        with:
+          image: "samba-server:nightly-fedora-amd64"
+          container_engine: ${{ env.CONTAINER_CMD }}
+      # (ad server images)
+      - name: Fetch ad-server default-fedora-amd64
+        uses: ishworkh/container-image-artifact-download@v1.0.0
+        with:
+          image: "samba-ad-server:default-fedora-amd64"
+          container_engine: ${{ env.CONTAINER_CMD }}
+      - name: Fetch ad-server nightly-fedora-amd64
+        uses: ishworkh/container-image-artifact-download@v1.0.0
+        with:
+          image: "samba-ad-server:nightly-fedora-amd64"
+          container_engine: ${{ env.CONTAINER_CMD }}
+      # (client images)
+      - name: Fetch client default-fedora-amd64
+        uses: ishworkh/container-image-artifact-download@v1.0.0
+        with:
+          image: "samba-client:default-fedora-amd64"
+          container_engine: ${{ env.CONTAINER_CMD }}
+      # (toolbox images)
+      - name: Fetch toolbox default-fedora-amd64
+        uses: ishworkh/container-image-artifact-download@v1.0.0
+        with:
+          image: "samba-toolbox:default-fedora-amd64"
+          container_engine: ${{ env.CONTAINER_CMD }}
+      # reapply missing tags
+      - name: Retag images
+        run: >
+          ./hack/build-image
+          --retag
+          --container-engine=${CONTAINER_CMD}
+          --repo-base=${REPO_BASE}
+          --no-distro-qualified
+          -i samba-server:default-fedora-amd64
+          -i samba-server:nightly-fedora-amd64
+          -i samba-ad-server:default-fedora-amd64
+          -i samba-ad-server:nightly-fedora-amd64
+          -i samba-client:default-fedora-amd64
+          -i samba-toolbox:default-fedora-amd64
+      - name: Push images
+        run: >
+          ./hack/build-image
+          --push
+          --container-engine=${CONTAINER_CMD}
+          --verbose
+          --push-state=exists
+          --push-selected-tags=mixed
+          -i ${REPO_BASE}/samba-server:default-fedora-amd64
+          -i ${REPO_BASE}/samba-server:nightly-fedora-amd64
+          -i ${REPO_BASE}/samba-ad-server:default-fedora-amd64
+          -i ${REPO_BASE}/samba-ad-server:nightly-fedora-amd64
+          -i ${REPO_BASE}/samba-client:default-fedora-amd64
+          -i ${REPO_BASE}/samba-toolbox:default-fedora-amd64

--- a/hack/build-image
+++ b/hack/build-image
@@ -252,6 +252,26 @@ def container_id(cli, target):
     return res.stdout.decode("utf8").strip()
 
 
+def container_tag(cli, target, tag, *tags):
+    """Add additional tags to the existing target image."""
+    if isinstance(target, str):
+        src = target  # permit target to be a string w/ the desired source
+    else:
+        src = target.image_name()
+    base_args = [
+        container_engine(cli),
+        "tag",
+        src,
+    ]
+    if "docker" not in base_args[0]:
+        # podman can do it in one command, docker (on github ci) can not
+        args += [tag] + list(tags)
+        run(cli, args, check=True)
+        return
+    for new_tag in [tag] + list(tags):
+        run(cli, base_args + [new_tag], check=True)
+
+
 def kind_source_dir(kind):
     """Return the path to a kind's source directory."""
     return pathlib.Path("images") / SOURCE_DIRS[check_kind(kind)]
@@ -477,6 +497,24 @@ def push(cli, target):
             container_push(cli, push_name)
 
 
+def retag(cli, target):
+    """Command to regenerate any missing unqualified tags."""
+    cid = container_id(cli, target)
+    tags = []
+    if cli.repo_base and target.repo_base != cli.repo_base:
+        # if repo base is given on the cli, and differs from the
+        # target, regenerate tags with the new distro base.
+        # retag list
+        target.repo_base = cli.repo_base
+        # Ensure the new FQIN is part of the new tags list
+        tags.append(target.image_name())
+    tags += [target.image_name(tag=t) for t, _ in target.additional_tags]
+    if tags:
+        container_tag(cli, cid, *tags)
+    else:
+        logger.warning("no tags to add")
+
+
 def print_buildfile(cli, target):
     """Command to print build file names."""
     build_file = pathlib.Path(f"{cli.buildfile_prefix}{target.flat_name()}")
@@ -653,6 +691,14 @@ def main():
         dest="main_action",
         const=print_buildfile,
         help="Print the names of build status files",
+    )
+    behaviors.add_argument(
+        "--retag",
+        action="store_const",
+        dest="main_action",
+        const=retag,
+        help=("Regenerate any short (unqualified) tags expected to exist"
+              " for a given FQIN. Requires FQIN to already exist locally."),
     )
     cli = parser.parse_args()
 

--- a/hack/build-image
+++ b/hack/build-image
@@ -121,6 +121,7 @@ DEFAULT_DISTRO_BASES = [FEDORA]
 LATEST = "latest"
 QUAL_NONE = "unqualified"
 QUAL_DISTRO = "distro-qualified"
+QUAL_FQIN = 'fqin'
 
 
 _DISCOVERED_CONTAINER_ENGINES = []
@@ -405,6 +406,53 @@ def build(cli, target):
         fh.write(f"{cid} {target.image_name()}\n")
 
 
+class QMatcher:
+    """Push only tags that meet the specified criteria:
+    all - all tags;
+    unqualified - only unqualified tags (eg. latest);
+    distro - only distribution base qualifed tags (eg. fedora-latest);
+    fqin - only fully qualified tags (eg. default-centos-amd64);
+    mixed - only fqin and unqualified tags;
+    least-qualified (default) - exactly one tag, with the least
+    number of qualifications
+    """
+
+    def __init__(self, key):
+        self.qualifications = []
+        self.count = 0
+        self.max_matches = 0
+
+        if not key or key == "least-qualified":
+            self.qualifications = [QUAL_NONE, QUAL_DISTRO, QUAL_FQIN]
+            self.max_matches = 1
+        elif key == "all":
+            pass
+        elif key == "mixed":
+            self.qualifications = [QUAL_NONE, QUAL_FQIN]
+        else:
+            try:
+                mq = {
+                    "unqualified": QUAL_NONE,
+                    "distro": QUAL_DISTRO,
+                    "fqin": QUAL_FQIN,
+                }[key]
+            except KeyError:
+                raise argparse.ArgumentTypeError(
+                    "value must be one of:"
+                    " all, least-qualified, unqualified, distro, fqin;"
+                    f" not {key}"
+                )
+            self.qualifications = [mq]
+
+    def __call__(self, qv):
+        if self.max_matches and self.count >= self.max_matches:
+            return False
+        if not self.qualifications or qv in self.qualifications:
+            self.count += 1
+            return True
+        return False
+
+
 def push(cli, target):
     """Command to push images."""
     if cli.push_state == "rebuild":
@@ -415,15 +463,18 @@ def push(cli, target):
         except subprocess.CalledProcessError:
             build(cli, target)
 
+    to_push = []
     push_name = target.image_name()
-    for tag, _ in target.additional_tags:
+    for tag, qual in target.additional_tags:
         if tag in ("latest", "nightly"):
-            push_name = target.image_name(tag=tag)
-            break
+            to_push.append((target.image_name(tag=tag), qual))
         if tag.endswith(("-latest", "-nightly")):
-            push_name = target.image_name(tag=tag)
-            break
-    container_push(cli, push_name)
+            to_push.append((target.image_name(tag=tag), qual))
+    to_push.append((push_name, QUAL_FQIN))
+    qmatcher = cli.push_selected_tags or QMatcher("")
+    for push_name, tag_qual in to_push:
+        if qmatcher(tag_qual):
+            container_push(cli, push_name)
 
 
 def print_buildfile(cli, target):
@@ -539,6 +590,11 @@ def main():
             "Only push if a state is met:"
             "exists - image exists; rebuild - image must be rebuilt."
         ),
+    )
+    parser.add_argument(
+        "--push-selected-tags",
+        type=QMatcher,
+        help=QMatcher.__doc__
     )
     parser.add_argument(
         "--buildfile-prefix",


### PR DESCRIPTION
The following changes update the build-image script so that it's easier to update the tags for existing images and helps control what tags are pushed when the push command is invoked.

Then we restructure the push job so that it avoids rebuilding the images we just built and test and instead reimports them from the artifacts and then uses the new retag command to fix up the tags and distro base followed by pushing them as both unqualified (`latest`, `nightly`) tags and fully-qualified tags.

Finally, we enable pushing the `samba-server:nightly-centos-amd64` and `samba-server:devbuilds-centos-amd64` to quay.io. The latter will be used for testing the ongoing SMB on Ceph work occurring in the Ceph project.