### PR TITLE
images/ad-server: Send debug output to standard output

### DIFF
--- a/images/ad-server/Containerfile.centos
+++ b/images/ad-server/Containerfile.centos
@@ -2,7 +2,7 @@ FROM quay.io/centos/centos:stream9
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
 ARG SAMBACC_VERSION_SUFFIX=""
-ARG SAMBA_SPECIFICS=
+ARG SAMBA_SPECIFICS=daemon_cli_debug_output
 ARG INSTALL_CUSTOM_REPO=
 
 MAINTAINER John Mulligan <jmulligan@redhat.com>

--- a/images/ad-server/Containerfile.fedora
+++ b/images/ad-server/Containerfile.fedora
@@ -2,7 +2,7 @@ FROM registry.fedoraproject.org/fedora:39
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
 ARG SAMBACC_VERSION_SUFFIX=""
-ARG SAMBA_SPECIFICS=
+ARG SAMBA_SPECIFICS=daemon_cli_debug_output
 ARG INSTALL_CUSTOM_REPO=
 
 MAINTAINER John Mulligan <jmulligan@redhat.com>

--- a/images/ad-server/Containerfile.opensuse
+++ b/images/ad-server/Containerfile.opensuse
@@ -6,7 +6,7 @@
 
 # OBS doesn't allow a fully qualified image registry name for the offline build
 FROM opensuse/tumbleweed
-ARG SAMBA_SPECIFICS=
+ARG SAMBA_SPECIFICS=daemon_cli_debug_output
 
 MAINTAINER David Mulder <dmulder@suse.com>
 


### PR DESCRIPTION
_/usr/sbin/samba_ also comes with a similar option as others to print logs to standard output. Make use of `SAMBA_SPECIFICS` argument to specify required value to finally run with `--debug-stdout` option.

depends on https://github.com/samba-in-kubernetes/sambacc/pull/106