### PR TITLE
workflows: allow manually running the ci job

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -7,6 +7,9 @@ on:
     branches: [master]
   schedule:
     - cron: '0 2 * * *'
+  # Allow manually triggering a run in the github ui.
+  # See: https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow
+  workflow_dispatch: {}
 
 env:
   CONTAINER_CMD: docker


### PR DESCRIPTION
Add a workflow_dispatch event trigger so that the team (specifically, me when I am being impatient) can trigger a manual CI run and eventually image push to quay.io