### PR TITLE
images/server: Install ctdb-ceph-mutex for rados helper

### DIFF
--- a/images/server/install-packages.sh
+++ b/images/server/install-packages.sh
@@ -95,11 +95,11 @@ samba_packages=(\
     ctdb)
 case "${package_selection}-${OS_BASE}" in
     *-fedora|allvfs-*)
-        samba_packages+=(samba-vfs-cephfs samba-vfs-glusterfs)
+        samba_packages+=(samba-vfs-cephfs samba-vfs-glusterfs ctdb-ceph-mutex)
     ;;
     nightly-centos|devbuilds-centos|forcedevbuilds-*)
         dnf_cmd+=(--enablerepo=epel)
-        samba_packages+=(samba-vfs-cephfs)
+        samba_packages+=(samba-vfs-cephfs ctdb-ceph-mutex)
         # these packages should be installed as deps. of sambacc extras
         # however, the sambacc builds do not enable the extras on centos atm.
         # Once this is fixed this line ought to be removed.


### PR DESCRIPTION
`ctdb-rados-mutex` subcommand to `samba-container` expects the required rados helper binary to be present for execution. Therefore install the necessary ctdb-ceph-mutex package providing ctdb_mutex_ceph_rados_helper in various image flavours.