### PR TITLE
workflows: allow push on manually run workflows

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -233,7 +233,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REPO_BASE: quay.io/samba.org
-    if: (github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'samba-in-kubernetes/samba-container'
+    # NOTE: the fromJSON below is needed beause the syntax github uses
+    # doesn't actually understand JS/JSON style arrays (inline). When I left it
+    # out I just got an error. It is present in their example(s).
+    if: >
+      contains(fromJSON('["push", "schedule", "workflow_dispatch"]'), github.event_name)
+      && github.repository == 'samba-in-kubernetes/samba-container'
     steps:
       - uses: actions/checkout@v4
       - name: log in to quay.io


### PR DESCRIPTION
A while back we enabled running workflow manually in the action (with a button on the github ui) via the workflow_dispatch type. However, this action doesn't run the 'push' step because push is only included with a scheduled run or a merged pr. Rework the line so that push is performed for scheduled runs, merged prs, or manual runs. This is useful in case something samba-container depends on is updated and one doesn't feel like waiting all day for a scheduled run.