### PR TITLE
workflows: update to newer ishworkh/container-image-artifact-* actions

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Build the server image
         run: make KIND=server PACKAGE_SOURCE=${{ matrix.package_source }} OS_NAME=${{ matrix.os}} BUILD_ARCH=${{ matrix.arch}} build-image
       - name: Upload server image
-        uses: ishworkh/container-image-artifact-upload@v1.0.0
+        uses: ishworkh/container-image-artifact-upload@v2.0.0
         with:
           image: "samba-server:${{ env.IMG_TAG }}"
           container_engine: ${{ env.CONTAINER_CMD }}
@@ -91,7 +91,7 @@ jobs:
       - name: Build the ad server image
         run: make KIND=ad-server PACKAGE_SOURCE=${{ matrix.package_source }} OS_NAME=${{ matrix.os }} BUILD_ARCH=${{ matrix.arch }} build-image
       - name: Upload ad server image
-        uses: ishworkh/container-image-artifact-upload@v1.0.0
+        uses: ishworkh/container-image-artifact-upload@v2.0.0
         with:
           image: "samba-ad-server:${{ env.IMG_TAG }}"
           container_engine: ${{ env.CONTAINER_CMD }}
@@ -112,7 +112,7 @@ jobs:
         run: make KIND=client OS_NAME=${{ matrix.os }} BUILD_ARCH=${{ matrix.arch }} build-image
       # The client image is used as a base for the samba-toolbox build process.
       - name: Upload the client image
-        uses: ishworkh/container-image-artifact-upload@v1.0.0
+        uses: ishworkh/container-image-artifact-upload@v2.0.0
         with:
           image: "samba-client:${{ env.IMG_TAG }}"
           container_engine: ${{ env.CONTAINER_CMD }}
@@ -133,7 +133,7 @@ jobs:
       # Download locally stored samba-client image to be used as base for building
       # samba-toolbox.
       - name: Download client image
-        uses: ishworkh/container-image-artifact-download@v1.0.0
+        uses: ishworkh/container-image-artifact-download@v2.0.0
         with:
           image: "samba-client:${{ env.IMG_TAG }}"
           container_engine: ${{ env.CONTAINER_CMD }}
@@ -147,7 +147,7 @@ jobs:
         run: make KIND=toolbox OS_NAME=${{ matrix.os }}  BUILD_ARCH=${{ matrix.arch }} build-image
       # Upload the toolbox image for reference and/or image push
       - name: Upload the toolbox image
-        uses: ishworkh/container-image-artifact-upload@v1.0.0
+        uses: ishworkh/container-image-artifact-upload@v2.0.0
         with:
           image: "samba-toolbox:${{ env.IMG_TAG }}"
           container_engine: ${{ env.CONTAINER_CMD }}
@@ -175,7 +175,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download server image
-        uses: ishworkh/container-image-artifact-download@v1.0.0
+        uses: ishworkh/container-image-artifact-download@v2.0.0
         with:
           image: "samba-server:${{ env.IMG_TAG }}"
           container_engine: ${{ env.CONTAINER_CMD }}
@@ -209,12 +209,12 @@ jobs:
       - name: get nodes
         run: kubectl get nodes
       - name: Download ad server image
-        uses: ishworkh/container-image-artifact-download@v1.0.0
+        uses: ishworkh/container-image-artifact-download@v2.0.0
         with:
           image: "samba-ad-server:${{ env.IMG_TAG }}"
           container_engine: ${{ env.CONTAINER_CMD }}
       - name: Download file server image
-        uses: ishworkh/container-image-artifact-download@v1.0.0
+        uses: ishworkh/container-image-artifact-download@v2.0.0
         with:
           image: "samba-server:${{ env.IMG_TAG }}"
           container_engine: ${{ env.CONTAINER_CMD }}
@@ -246,45 +246,45 @@ jobs:
       # pull in already built images we plan on pushing
       # (server images)
       - name: Fetch server default-fedora-amd64
-        uses: ishworkh/container-image-artifact-download@v1.0.0
+        uses: ishworkh/container-image-artifact-download@v2.0.0
         with:
           image: "samba-server:default-fedora-amd64"
           container_engine: ${{ env.CONTAINER_CMD }}
       - name: Fetch server nightly-fedora-amd64
-        uses: ishworkh/container-image-artifact-download@v1.0.0
+        uses: ishworkh/container-image-artifact-download@v2.0.0
         with:
           image: "samba-server:nightly-fedora-amd64"
           container_engine: ${{ env.CONTAINER_CMD }}
       - name: Fetch server nightly-centos-amd64
-        uses: ishworkh/container-image-artifact-download@v1.0.0
+        uses: ishworkh/container-image-artifact-download@v2.0.0
         with:
           image: "samba-server:nightly-centos-amd64"
           container_engine: ${{ env.CONTAINER_CMD }}
       - name: Fetch server devbuilds-centos-amd64
-        uses: ishworkh/container-image-artifact-download@v1.0.0
+        uses: ishworkh/container-image-artifact-download@v2.0.0
         with:
           image: "samba-server:devbuilds-centos-amd64"
           container_engine: ${{ env.CONTAINER_CMD }}
       # (ad server images)
       - name: Fetch ad-server default-fedora-amd64
-        uses: ishworkh/container-image-artifact-download@v1.0.0
+        uses: ishworkh/container-image-artifact-download@v2.0.0
         with:
           image: "samba-ad-server:default-fedora-amd64"
           container_engine: ${{ env.CONTAINER_CMD }}
       - name: Fetch ad-server nightly-fedora-amd64
-        uses: ishworkh/container-image-artifact-download@v1.0.0
+        uses: ishworkh/container-image-artifact-download@v2.0.0
         with:
           image: "samba-ad-server:nightly-fedora-amd64"
           container_engine: ${{ env.CONTAINER_CMD }}
       # (client images)
       - name: Fetch client default-fedora-amd64
-        uses: ishworkh/container-image-artifact-download@v1.0.0
+        uses: ishworkh/container-image-artifact-download@v2.0.0
         with:
           image: "samba-client:default-fedora-amd64"
           container_engine: ${{ env.CONTAINER_CMD }}
       # (toolbox images)
       - name: Fetch toolbox default-fedora-amd64
-        uses: ishworkh/container-image-artifact-download@v1.0.0
+        uses: ishworkh/container-image-artifact-download@v2.0.0
         with:
           image: "samba-toolbox:default-fedora-amd64"
           container_engine: ${{ env.CONTAINER_CMD }}


### PR DESCRIPTION
Take the newest version of these actions and stop generating warnings about node versions in github.