### PR TITLE
hack: Fix variable reference before assignment

### DIFF
--- a/hack/build-image
+++ b/hack/build-image
@@ -265,7 +265,7 @@ def container_tag(cli, target, tag, *tags):
     ]
     if "docker" not in base_args[0]:
         # podman can do it in one command, docker (on github ci) can not
-        args += [tag] + list(tags)
+        args = base_args + [tag] + list(tags)
         run(cli, args, check=True)
         return
     for new_tag in [tag] + list(tags):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/root/master/./hack/build-image", line 726, in <module>
    main()
  File "/root/master/./hack/build-image", line 716, in main
    _action(cli, img)
  File "/root/master/./hack/build-image", line 513, in retag
    container_tag(cli, cid, *tags)
  File "/root/master/./hack/build-image", line 268, in container_tag
    args += [tag] + list(tags)
UnboundLocalError: local variable 'args' referenced before assignment
```