### PR TITLE
images: update fedora base images to fedora 41

### DIFF
--- a/images/ad-server/Containerfile.fedora
+++ b/images/ad-server/Containerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:40
+FROM registry.fedoraproject.org/fedora:41
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
 ARG SAMBACC_VERSION_SUFFIX=""

--- a/images/client/Containerfile.fedora
+++ b/images/client/Containerfile.fedora
@@ -1,6 +1,6 @@
 # Copyright 2020 Michael Adam
 
-FROM registry.fedoraproject.org/fedora:40
+FROM registry.fedoraproject.org/fedora:41
 
 MAINTAINER Michael Adam <obnox@samba.org>
 

--- a/images/server/Containerfile.fedora
+++ b/images/server/Containerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:40
+FROM registry.fedoraproject.org/fedora:41
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
 ARG SAMBACC_VERSION_SUFFIX=""


### PR DESCRIPTION
With the recent release of samba-container and the recent-ish release of Fedora 41, we can start using the latest active Fedora as our base image.