### PR TITLE
images/server: Enable resilientstorage only for non-nightly builds

### DIFF
--- a/images/server/install-packages.sh
+++ b/images/server/install-packages.sh
@@ -101,7 +101,10 @@ esac
 
 dnf_cmd=(dnf)
 if [[ "${OS_BASE}" = centos ]]; then
-    dnf_cmd+=(--enablerepo=crb --enablerepo=resilientstorage)
+    dnf_cmd+=(--enablerepo=crb)
+    if [[ "${package_selection}" != "nightly" && "${package_selection}" != "devbuilds" ]]; then
+        dnf_cmd+=(--enablerepo=resilientstorage)
+    fi
 fi
 
 


### PR DESCRIPTION
Resilient Storage is only required when ctdb packages are installed from standard repositories. Therefore avoid enabling it for container builds with samba nightly rpms.