### PR TITLE
images/server: Use `$basearch` in ceph devbuilds repo file

### DIFF
--- a/images/server/install-packages.sh
+++ b/images/server/install-packages.sh
@@ -33,7 +33,7 @@ ref = r[0]["ref"]
 with open(dest, "w") as out:
     print(f"[ceph-{ref}]", file=out)
     print(f"name=Ceph Development Build ({ref})", file=out)
-    print(f"baseurl={url}/x86_64", file=out)
+    print(f"baseurl={url}/\$basearch", file=out)
     print("enabled=1", file=out)
     print("gpgcheck=0", file=out)
 EOF


### PR DESCRIPTION
Remove the hardcoded 'x86_64' value from generated repo file for ceph development builds and use standard `$basearch` dnf repo variable.