### PR TITLE
common:  implement an explicit preference order in sambacc installation

### DIFF
--- a/images/common/install-sambacc-common.sh
+++ b/images/common/install-sambacc-common.sh
@@ -30,28 +30,42 @@ install_sambacc() {
     done
 
 
-    local action=install-from-copr-repo
-    if [ "${#wheels[@]}" -gt 1 ]; then
-        echo "more than one wheel file found"
-        exit 1
-    elif [ "${#wheels[@]}" -eq 1 ]; then
-        action=install-wheel
+    local action="" 
+    echo "INFO: determining sambacc installation source." 
+    if [ "${#wheels[@]}" -gt 0 ]; then
+        echo "INFO: wheel found"
+        if [ "${#wheels[@]}" -gt 1 ]; then
+            echo "ERROR: more than one wheel file found"
+            exit 1
+        elif [ "${#wheels[@]}" -eq 1  ]; then
+            action=install-wheel
+        fi
+    fi
+    if [ "${#rpmfiles[@]}" -gt 0 ]; then
+        echo "INFO: rpm file found"
+        if [ "${#rpmfiles[@]}" -gt 1 ]; then
+            echo "ERROR: more than one sambacc rpm file found"
+            exit 1
+        elif [ "${#rpmfiles[@]}" -eq 1 ]; then
+            action=install-rpm
+        fi
+    fi
+    if [ "${#repofiles[@]}" -gt 0 ]; then
+       echo  "INFO: repo file found"
+       if [ "${#repofiles[@]}" -gt 1 ]; then
+           echo "ERROR: more than one repo file found"
+           exit 1
+       elif [ "${#repofiles[@]}" -eq 1 ]; then
+           action=install-from-repo
+       fi
+    fi
+    if [ -z "${action}" ]; then
+
+        echo "INFO: no local sambacc installation source found. falling back to copr install."
+        action=install-from-copr-repo
     fi
 
-    if [ "${#rpmfiles[@]}" -gt 1 ]; then
-        echo "more than one sambacc rpm file found"
-        exit 1
-    elif [ "${#rpmfiles[@]}" -eq 1 ]; then
-        action=install-rpm
-    fi
-
-    if [ "${#repofiles[@]}" -gt 1 ]; then
-        echo "more than one repo file found"
-        exit 1
-    elif [ "${#repofiles[@]}" -eq 1 ]; then
-        action=install-from-repo
-    fi
-
+    echo "INFO: selected installation method: '${action}'"
     if [ -z "${DEFAULT_JSON_FILE}" ]; then
         echo "DEFAULT_JSON_FILE value unset"
         exit 1


### PR DESCRIPTION
 this explicitly implements a preference order for sambacc
    custom installation sources like so:

    local repo ->  -> rpm ->  wheel   -> copr.

 It makes the output a bit more verbose while at it.
overall, the behavior of the sambacc installation is made a bit more consistent and predictable
  