### PR TITLE
workflows: use ubuntu-latest everywhere

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -205,8 +205,7 @@ jobs:
     needs:
       - build-ad-server
       - build-server
-    # need to explicitly use 20.04 to avoid problems with jq...
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BUILDAH_FORMAT: oci
       IMG_TAG: ${{ matrix.package_source }}-${{ matrix.os }}-${{ matrix.arch }}


### PR DESCRIPTION
Github has disabled ubuntu 20.04:
  `This is a scheduled Ubuntu 20.04 retirement.`
Update to ubuntu latest to find out what jq issue the comment was referring to.