### PR TITLE
docs: add dnf repo support to scc builder example

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -74,6 +74,10 @@ ARG SAMBACC_VER=my-cool-branch
 ARG SAMBACC_REPO=https://github.com/example-user/sambacc
 RUN SAMBACC_DISTNAME=latest \
     /usr/local/bin/build.sh ${SAMBACC_VER} ${SAMBACC_REPO}
+# create yum/dnf repo for temp. packages (file uses paths in dest container)
+RUN dnf install -y /usr/bin/createrepo_c \
+    && createrepo_c /srv/dist/latest \
+    && echo -e '[sambacc]\nbaseurl=file:///tmp/sambacc-dist-latest\nenabled=1\ngpgcheck=0\n' > /srv/dist/latest/sambacc.repo
 # --- end new stuff ---
 
 FROM registry.fedoraproject.org/fedora:38


### PR DESCRIPTION
In the development doc the *Build Stage* section documents a method for building sambacc packages that will become part of the final samba-server image. This is very handy for practical testing of sambacc changes. But the document is a bit out of date in that the pure "find rpms and install them" method doesn't work well when the extras are needed.
Update the file to document creating a yum/dnf repo and .repo file such that dnf will be used with the sambacc target package in order for `Recommends` to be considered during the install.