### PR TITLE
Add `ceph20` package source corresponding to ceph tentacle 

### DIFF
--- a/hack/build-image
+++ b/hack/build-image
@@ -99,12 +99,14 @@ DISTROS = [
 DEFAULT = "default"
 NIGHTLY = "nightly"
 DEVBUILDS = "devbuilds"
-PACKAGE_SOURCES = [DEFAULT, NIGHTLY, DEVBUILDS]
+CEPH20 = "ceph20"
+PACKAGE_SOURCES = [DEFAULT, NIGHTLY, DEVBUILDS, CEPH20]
 
 PACKAGES_FROM = {
     DEFAULT: "",
     NIGHTLY: "samba-nightly",
     DEVBUILDS: "devbuilds",
+    CEPH20: "ceph20",
 }
 
 # SOURCE_DIRS - image source paths

--- a/images/server/install-packages.sh
+++ b/images/server/install-packages.sh
@@ -46,15 +46,25 @@ get_samba_nightly_repo() {
 
 get_sig_samba_repo() {
     if [[ "${OS_BASE}" = centos ]]; then
-        dnf install --setopt=install_weak_deps=False -y \
-            centos-release-samba
+        if [[ -z $1 ]]; then
+            dnf install --setopt=install_weak_deps=False -y \
+                centos-release-samba
+        else
+            dnf install --setopt=install_weak_deps=False -y \
+                centos-release-samba"${1//.}"
+        fi
     fi
 }
 
 get_distro_ceph_repo() {
     if [[ "${OS_BASE}" = centos ]]; then
-        dnf install --setopt=install_weak_deps=False -y \
-            centos-release-ceph
+        if [[ -z $1 ]]; then
+            dnf install --setopt=install_weak_deps=False -y \
+                centos-release-ceph
+        else
+            dnf install --setopt=install_weak_deps=False -y \
+                centos-release-ceph-"${1}"
+        fi
     fi
 }
 
@@ -105,6 +115,11 @@ case "${install_packages_from}" in
         get_ceph_shaman_repo
         package_selection=${package_selection:-custom-devbuilds}
     ;;
+    ceph20)
+        get_sig_samba_repo "4.22"
+        get_distro_ceph_repo "tentacle"
+        package_selection=${package_selection:-stable}
+    ;;
     *)
         get_sig_samba_repo
         get_distro_ceph_repo
@@ -138,16 +153,13 @@ samba_packages=(\
     ctdb)
 case "${package_selection}-${OS_BASE}" in
     *-fedora|allvfs-*)
+        support_packages+=(libcephfs-proxy2)
         samba_packages+=(samba-vfs-cephfs samba-vfs-glusterfs ctdb-ceph-mutex)
     ;;
-    *devbuilds-centos|forcedevbuilds-*)
-	# Enable libcephfs proxy for dev builds
-        support_packages+=(libcephfs-proxy2)
-	# Fall through to next case
-    ;&
-    nightly-centos|default-centos)
+    *-centos|forcedevbuilds-*)
         dnf_cmd+=(--enablerepo=epel)
-        samba_packages+=(samba-vfs-cephfs ctdb-ceph-mutex)
+        support_packages+=(libcephfs-proxy2)
+        samba_packages+=(samba-vfs-cephfs samba-vfs-glusterfs ctdb-ceph-mutex)
         # these packages should be installed as deps. of sambacc extras
         # however, the sambacc builds do not enable the extras on centos atm.
         # Once this is fixed this line ought to be removed.


### PR DESCRIPTION
- Include _**libcephfs-proxy**_ for CentOS and Fedora
  - Generalize the switch case for CentOS
- Add **_samba-vfs-glusterfs_** for CentOS (available with Storage SIG)
- Update _build-image_ script with new `ceph20` package source