### PR TITLE
images: update base fedora image version to 42

### DIFF
--- a/images/ad-server/Containerfile.fedora
+++ b/images/ad-server/Containerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:41
+FROM registry.fedoraproject.org/fedora:42
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
 ARG SAMBACC_VERSION_SUFFIX=""

--- a/images/client/Containerfile.fedora
+++ b/images/client/Containerfile.fedora
@@ -1,6 +1,6 @@
 # Copyright 2020 Michael Adam
 
-FROM registry.fedoraproject.org/fedora:41
+FROM registry.fedoraproject.org/fedora:42
 
 MAINTAINER Michael Adam <obnox@samba.org>
 

--- a/images/server/Containerfile.fedora
+++ b/images/server/Containerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:41
+FROM registry.fedoraproject.org/fedora:42
 ARG INSTALL_PACKAGES_FROM=default
 ARG SAMBA_VERSION_SUFFIX=""
 ARG SAMBACC_VERSION_SUFFIX=""


### PR DESCRIPTION
Now we finally released v0.7 we can bump this up again.