### PR TITLE
Remove maintainers line

### DIFF
--- a/images/ad-server/Containerfile.centos
+++ b/images/ad-server/Containerfile.centos
@@ -5,11 +5,12 @@ ARG SAMBACC_VERSION_SUFFIX=""
 ARG SAMBA_SPECIFICS=daemon_cli_debug_output
 ARG INSTALL_CUSTOM_REPO=
 
-MAINTAINER John Mulligan <jmulligan@redhat.com>
-
 LABEL org.opencontainers.image.title="Samba ADDC container"
 LABEL org.opencontainers.image.description="Samba ADDC container"
 LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
+LABEL org.opencontainers.image.url="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.source="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.authors="The samba-container team, John Mulligan <jmulligan@redhat.com>"
 
 COPY install-packages.sh /usr/local/bin/install-packages.sh
 RUN /usr/local/bin/install-packages.sh \

--- a/images/ad-server/Containerfile.fedora
+++ b/images/ad-server/Containerfile.fedora
@@ -5,11 +5,12 @@ ARG SAMBACC_VERSION_SUFFIX=""
 ARG SAMBA_SPECIFICS=daemon_cli_debug_output
 ARG INSTALL_CUSTOM_REPO=
 
-MAINTAINER John Mulligan <jmulligan@redhat.com>
-
 LABEL org.opencontainers.image.title="Samba ADDC container"
 LABEL org.opencontainers.image.description="Samba ADDC container"
 LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
+LABEL org.opencontainers.image.url="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.source="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.authors="The samba-container team, John Mulligan <jmulligan@redhat.com>"
 
 COPY install-packages.sh /usr/local/bin/install-packages.sh
 RUN /usr/local/bin/install-packages.sh \

--- a/images/ad-server/Containerfile.opensuse
+++ b/images/ad-server/Containerfile.opensuse
@@ -8,14 +8,15 @@
 FROM opensuse/tumbleweed
 ARG SAMBA_SPECIFICS=daemon_cli_debug_output
 
-MAINTAINER David Mulder <dmulder@suse.com>
-
 # labelprefix=org.opensuse.samba-ad-server
 LABEL org.opencontainers.image.title="Samba ADDC container"
 LABEL org.opencontainers.image.description="Samba ADDC container"
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.version="%%PKG_VERSION%%-%RELEASE%"
 LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
+LABEL org.opencontainers.image.url="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.source="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.authors="David Mulder <dmulder@suse.com>"
 LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL org.opensuse.reference="registry.opensuse.org/opensuse/samba-ad-server:%%PKG_VERSION%%-%RELEASE%"
 # endlabelprefix

--- a/images/client/Containerfile.centos
+++ b/images/client/Containerfile.centos
@@ -2,12 +2,12 @@
 
 FROM quay.io/centos/centos:stream9
 
-MAINTAINER Michael Adam <obnox@samba.org>
-
 LABEL org.opencontainers.image.title="Samba Client container"
 LABEL org.opencontainers.image.description="Samba Client container"
 LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
 LABEL org.opencontainers.image.url="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.source="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.authors="The samba-container team, Michael Adam <obnox@samba.org>"
 
 
 # https://github.com/samba-in-kubernetes/samba-container/issues/96#issuecomment-1387467396

--- a/images/client/Containerfile.fedora
+++ b/images/client/Containerfile.fedora
@@ -2,12 +2,12 @@
 
 FROM registry.fedoraproject.org/fedora:42
 
-MAINTAINER Michael Adam <obnox@samba.org>
-
 LABEL org.opencontainers.image.title="Samba Client container"
 LABEL org.opencontainers.image.description="Samba Client container"
 LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
 LABEL org.opencontainers.image.url="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.source="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.authors="The samba-container team, Michael Adam <obnox@samba.org>"
 
 
 # https://github.com/samba-in-kubernetes/samba-container/issues/96#issuecomment-1387467396

--- a/images/client/Containerfile.opensuse
+++ b/images/client/Containerfile.opensuse
@@ -6,7 +6,6 @@
 
 # OBS doesn't allow a fully qualified image registry name for the offline build
 FROM opensuse/tumbleweed
-MAINTAINER David Mulder <dmulder@suse.com>
 
 # labelprefix=org.opensuse.samba-client
 LABEL org.opencontainers.image.title="Samba Client container"
@@ -14,6 +13,9 @@ LABEL org.opencontainers.image.description="Samba Client container"
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.version="%%PKG_VERSION%%-%RELEASE%"
 LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
+LABEL org.opencontainers.image.url="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.source="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.authors="David Mulder <dmulder@suse.com>"
 LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL org.opensuse.reference="registry.opensuse.org/opensuse/samba-client:%%PKG_VERSION%%-%RELEASE%"
 # endlabelprefix

--- a/images/server/Containerfile.centos
+++ b/images/server/Containerfile.centos
@@ -7,12 +7,12 @@ ARG INSTALL_CUSTOM_REPOS=
 ARG PACKAGE_SELECTION=
 ARG CEPH_FROM_CUSTOM=0
 
-MAINTAINER John Mulligan <jmulligan@redhat.com>
-
 LABEL org.opencontainers.image.title="Samba container"
 LABEL org.opencontainers.image.description="Samba container"
 LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
 LABEL org.opencontainers.image.url="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.source="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.authors="The samba-container team, John Mulligan <jmulligan@redhat.com>"
 
 
 COPY smb.conf /etc/samba/smb.conf

--- a/images/server/Containerfile.fedora
+++ b/images/server/Containerfile.fedora
@@ -6,12 +6,13 @@ ARG SAMBA_SPECIFICS=daemon_cli_debug_output,ctdb_leader_admin_command
 ARG INSTALL_CUSTOM_REPO=
 ARG PACKAGE_SELECTION=
 
-MAINTAINER John Mulligan <jmulligan@redhat.com>
-
 LABEL org.opencontainers.image.title="Samba container"
 LABEL org.opencontainers.image.description="Samba container"
 LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
 LABEL org.opencontainers.image.url="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.source="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.authors="The samba-container team, John Mulligan <jmulligan@redhat.com>"
+
 
 COPY smb.conf /etc/samba/smb.conf
 COPY install-packages.sh /usr/local/bin/install-packages.sh

--- a/images/server/Containerfile.opensuse
+++ b/images/server/Containerfile.opensuse
@@ -8,14 +8,15 @@
 FROM opensuse/tumbleweed
 ARG SAMBA_SPECIFICS=daemon_cli_debug_output,ctdb_leader_admin_command
 
-MAINTAINER David Mulder <dmulder@suse.com>
-
 # labelprefix=org.opensuse.samba-server
 LABEL org.opencontainers.image.title="Samba container"
 LABEL org.opencontainers.image.description="Samba container"
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.version="%%PKG_VERSION%%-%RELEASE%"
 LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
+LABEL org.opencontainers.image.url="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.source="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.authors="David Mulder <dmulder@suse.com>"
 LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL org.opensuse.reference="registry.opensuse.org/opensuse/samba-server:%%PKG_VERSION%%-%RELEASE%"
 # endlabelprefix

--- a/images/toolbox/Containerfile.centos
+++ b/images/toolbox/Containerfile.centos
@@ -4,12 +4,14 @@
 # This needs to be converted to something public and/or configurable
 # later.
 FROM quay.io/samba.org/samba-client:centos-latest
-MAINTAINER Shachar Sharon <ssharon@redhat.com>
 
 LABEL org.opencontainers.image.title="Samba Toolbox container"
 LABEL org.opencontainers.image.description="Samba Toolbox container"
 LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
 LABEL org.opencontainers.image.url="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.source="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.authors="The samba-container team, Shachar Sharon <ssharon@redhat.com>"
+
 
 RUN dnf install --enablerepo=crb -y \
     samba-test \

--- a/images/toolbox/Containerfile.fedora
+++ b/images/toolbox/Containerfile.fedora
@@ -1,10 +1,11 @@
 FROM quay.io/samba.org/samba-client:latest
-MAINTAINER Shachar Sharon <ssharon@redhat.com>
 
 LABEL org.opencontainers.image.title="Samba Toolbox container"
 LABEL org.opencontainers.image.description="Samba Toolbox container"
 LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
 LABEL org.opencontainers.image.url="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.source="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.authors="The samba-container team, Shachar Sharon <ssharon@redhat.com>"
 
 
 RUN dnf -y install samba-test \

--- a/images/toolbox/Containerfile.opensuse
+++ b/images/toolbox/Containerfile.opensuse
@@ -6,7 +6,6 @@
 
 # OBS doesn't allow a fully qualified image registry name for the offline build
 FROM opensuse/tumbleweed
-MAINTAINER David Mulder <dmulder@suse.com>
 
 # labelprefix=org.opensuse.samba-toolbox
 LABEL org.opencontainers.image.title="Samba Toolbox container"
@@ -14,6 +13,9 @@ LABEL org.opencontainers.image.description="Samba Toolbox container"
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.version="%%PKG_VERSION%%-%RELEASE%"
 LABEL org.opencontainers.image.vendor="Samba in Kubernetes"
+LABEL org.opencontainers.image.url="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.source="https://github.com/samba-in-kubernetes/samba-container"
+LABEL org.opencontainers.image.authors="David Mulder <dmulder@suse.com>"
 LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL org.opensuse.reference="registry.opensuse.org/opensuse/samba-toolbox:%%PKG_VERSION%%-%RELEASE%"
 # endlabelprefix


### PR DESCRIPTION
Our CI is logging warnings from docker complaining that the MAINTAINER line is deprecated.  Let's modernize and remove that line.

Fixes: #214 