### PR TITLE
workflows: disable fail-fast on build matrixes

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -42,6 +42,7 @@ jobs:
     # Reminder: the nightly-server images consume nightly samba rpm builds
     # it is not *just* an image that gets built nightly
     strategy:
+      fail-fast: false
       matrix:
         package_source: [default, nightly]
         os: [centos, fedora, opensuse]
@@ -91,6 +92,7 @@ jobs:
 
   build-ad-server:
     strategy:
+      fail-fast: false
       matrix:
         package_source: [default, nightly]
         os: [centos, fedora, opensuse]
@@ -128,6 +130,7 @@ jobs:
 
   build-client:
     strategy:
+      fail-fast: false
       matrix:
         os: [centos, fedora, opensuse]
         arch:
@@ -158,6 +161,7 @@ jobs:
 
   build-toolbox:
     strategy:
+      fail-fast: false
       matrix:
         os: [centos, fedora, opensuse]
         arch: [amd64]
@@ -202,6 +206,7 @@ jobs:
 
   test-server:
     strategy:
+      fail-fast: false
       matrix:
         package_source: [default, nightly]
         os: [centos, fedora, opensuse]
@@ -237,6 +242,7 @@ jobs:
 
   test-ad-server-kubernetes:
     strategy:
+      fail-fast: false
       matrix:
         package_source: [default, nightly]
         os: [centos, fedora, opensuse]


### PR DESCRIPTION
Fail-fast is nice if your failures are largely driven by invalid code but when the failures are caused by infra out of your control it can mask other issues. Disable fail-fast on our build jobs so we can monitor them independently while dealing with infra problems in ceph.