### PR TITLE
images/server: Use samba 4.24 for ceph tentacle builds

### DIFF
--- a/images/server/install-packages.sh
+++ b/images/server/install-packages.sh
@@ -163,7 +163,7 @@ case "${install_packages_from}" in
         package_selection=${package_selection:-custom-devbuilds}
     ;;
     ceph20)
-        get_sig_samba_repo "4.23"
+        get_sig_samba_repo "4.24"
         get_distro_ceph_repo "tentacle"
         package_selection=${package_selection:-stable}
     ;;


### PR DESCRIPTION
CentOS Stream 10 started shipping samba 4.24.x which conflicts with the 4.23 packages from the SIG samba repo during RPM installation. Update to 4.24 to resolve the package conflicts.