### PR TITLE
Add ceph21 package source corresponding to ceph umbrella

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -68,6 +68,14 @@ jobs:
           - package_source: ceph20
             os: centos
             arch: {name: arm64, host: ubuntu-24.04-arm}
+          # include ceph21 (umbrella) on centos only
+          - package_source: ceph21
+            os: centos
+            arch: {name: amd64, host: ubuntu-24.04}
+          - package_source: ceph21
+            os: centos
+            arch: {name: arm64, host: ubuntu-24.04-arm}
+
     name: build-server (${{ matrix.package_source}}, ${{ matrix.os }}, ${{ matrix.arch.name }})
     runs-on: ${{ matrix.arch.host }}
     env:
@@ -218,6 +226,9 @@ jobs:
           - package_source: ceph20
             os: centos
             arch: amd64
+          - package_source: ceph21
+            os: centos
+            arch: amd64
     needs: build-server
     runs-on: ubuntu-latest
     env:
@@ -333,6 +344,8 @@ jobs:
           --no-distro-qualified
           -i samba-server:ceph20-centos-amd64
           -i samba-server:ceph20-centos-arm64
+          -i samba-server:ceph21-centos-amd64
+          -i samba-server:ceph21-centos-arm64
           -i samba-server:default-centos-amd64
           -i samba-server:default-centos-arm64
           -i samba-server:default-fedora-amd64
@@ -361,6 +374,8 @@ jobs:
           --container-engine=${CONTAINER_CMD}
           -i ${REPO_BASE}/samba-server:ceph20-centos-amd64
           -i ${REPO_BASE}/samba-server:ceph20-centos-arm64
+          -i ${REPO_BASE}/samba-server:ceph21-centos-amd64
+          -i ${REPO_BASE}/samba-server:ceph21-centos-arm64
           -i ${REPO_BASE}/samba-server:default-centos-amd64
           -i ${REPO_BASE}/samba-server:default-centos-arm64
           -i ${REPO_BASE}/samba-server:default-fedora-amd64
@@ -397,6 +412,8 @@ jobs:
           --push-format=oci
           -i ${REPO_BASE}/samba-server:ceph20-centos-amd64
           -i ${REPO_BASE}/samba-server:ceph20-centos-arm64
+          -i ${REPO_BASE}/samba-server:ceph21-centos-amd64
+          -i ${REPO_BASE}/samba-server:ceph21-centos-arm64
           -i ${REPO_BASE}/samba-server:default-centos-amd64
           -i ${REPO_BASE}/samba-server:default-centos-arm64
           -i ${REPO_BASE}/samba-server:default-fedora-amd64

--- a/hack/build-image
+++ b/hack/build-image
@@ -104,7 +104,15 @@ NIGHTLY = "nightly"
 DEVBUILDS = "devbuilds"
 CUSTOM = "custom"
 CEPH20 = "ceph20"
-PACKAGE_SOURCES = [DEFAULT, NIGHTLY, DEVBUILDS, CUSTOM, CEPH20]
+CEPH21 = "ceph21"
+PACKAGE_SOURCES = [
+    DEFAULT,
+    NIGHTLY,
+    DEVBUILDS,
+    CUSTOM,
+    CEPH20,
+    CEPH21,
+]
 
 PACKAGES_FROM = {
     DEFAULT: "",
@@ -112,6 +120,7 @@ PACKAGES_FROM = {
     DEVBUILDS: "devbuilds",
     CUSTOM: "custom-repos",
     CEPH20: "ceph20",
+    CEPH21: "ceph21",
 }
 
 # SOURCE_DIRS - image source paths

--- a/images/server/install-packages.sh
+++ b/images/server/install-packages.sh
@@ -165,6 +165,11 @@ case "${install_packages_from}" in
         get_distro_ceph_repo "tentacle"
         package_selection=${package_selection:-stable}
     ;;
+    ceph21)
+        get_sig_samba_repo "4.24"
+        get_distro_ceph_repo "umbrella"
+        package_selection=${package_selection:-stable}
+    ;;
     *)
         get_sig_samba_repo
         get_distro_ceph_repo


### PR DESCRIPTION
- Create and enable a new `ceph21` package source
- Update _build-image_ script with new `ceph21` package source

depends on #259 
