### PR TITLE
images/server: Do not install distro ceph proactively

### DIFF
--- a/images/server/install-packages.sh
+++ b/images/server/install-packages.sh
@@ -14,9 +14,6 @@ get_custom_repos() {
     if [[ -n $1 ]]; then
         urls=$1
         need_curl
-        if [[ $ceph_from_custom -ne 1 ]]; then
-            get_distro_ceph_repo
-        fi
         for url in $urls; do
             fname="$(basename "$url")"
             dest="/etc/yum.repos.d/${fname}"
@@ -110,6 +107,7 @@ get_ceph_shaman_repo() {
 
 if [[ "$1" =~ ^--.+$ ]]; then
     # named (activated if first arg starts with `--`
+    # shellcheck disable=SC2034
     for arg in "$@"; do
         case "$arg" in
             --install-packages-from=*) install_packages_from="${arg/*=/}" ;;


### PR DESCRIPTION
Package sources that require samba nightly builds were unwantedly installing distro ceph packages because _get_custom_repos()_ had a check for `ceph_from_custom` which always evaluates to true unless the `--ceph-from-custom` option is explicitly set. This check is unnecessary because every package source already explicitly configures the ceph repo in a subsequent step, except `custom-repos` for which `--ceph-from-custom` is expected to be present anyway.

Remove the conditional _get_distro_ceph_repo()_ call from _get_custom_repos()_ to prevent distro ceph packages from being installed prematurely.