### PR TITLE
images/server: include nss-altfiles in server container

### DIFF
--- a/images/server/install-packages.sh
+++ b/images/server/install-packages.sh
@@ -188,6 +188,7 @@ fi
 # support the functioning of the container
 support_packages=(\
     findutils \
+    nss-altfiles \
     python-pip \
     python3-samba \
     python3-pyxattr \


### PR DESCRIPTION
needed for https://github.com/samba-in-kubernetes/sambacc/pull/215